### PR TITLE
Add labeled index-derived zones

### DIFF
--- a/docs/psychchart_user_docs_markdown/docs/config/zones.md
+++ b/docs/psychchart_user_docs_markdown/docs/config/zones.md
@@ -1,5 +1,13 @@
 # `zones` e `index_zones` — regiões do gráfico
 
+O psychChart possui dois mecanismos para representar áreas no diagrama psicrométrico.
+
+`zones` representa zonas geométricas, definidas diretamente por vértices ou por intervalos de temperatura e umidade relativa.
+
+`index_zones` representa zonas calculadas a partir de uma faixa de índice. Esse é o mecanismo correto para pintar uma área baseada em ITU, HLI ou outro índice registrado.
+
+---
+
 ## `zones`
 
 ## O que é
@@ -8,11 +16,9 @@ Zona geométrica definida por vértices explícitos ou por intervalos de tempera
 
 ## Para que serve
 
-Serve para representar regiões como conforto, alerta, operação admissível ou qualquer outra área de interesse no gráfico.
+Serve para representar regiões como conforto, alerta, operação admissível, envelope experimental ou qualquer outra área definida diretamente no espaço psicrométrico.
 
 ## Parâmetros disponíveis
-
-### Confirmado no código
 
 - `name`
 - `vertices`
@@ -23,20 +29,16 @@ Serve para representar regiões como conforto, alerta, operação admissível ou
 - `facecolor`
 - `linewidth`
 - `alpha`
-
-## Valores aceitos
-
-- `name`: texto.
-- `vertices`: lista de pares numéricos.
-- `t_range`: par numérico.
-- `rh_range`: par numérico.
-- `follow_rh`: booleano.
-- `edgecolor`, `facecolor`: texto.
-- `linewidth`, `alpha`: número.
+- `show_label`
+- `label`
+- `label_t`
+- `label_rh`
+- `label_color`
+- `label_fontsize`
+- `label_rotation`
+- `label_bbox`
 
 ## Exemplo de uso
-
-### Zona por intervalos
 
 ```yaml
 zones:
@@ -48,39 +50,17 @@ zones:
     facecolor: lightgreen
     linewidth: 1.5
     alpha: 0.3
-```
-
-### Zona por vértices
-
-```yaml
-zones:
-  - name: comfort_polygon
-    vertices:
-      - [20.0, 0.006]
-      - [24.0, 0.007]
-      - [26.0, 0.009]
-    edgecolor: green
-    facecolor: lightgreen
+    show_label: true
+    label: "Comfort"
+    label_t: 22
+    label_rh: 55
 ```
 
 ## Observações importantes
 
-### Confirmado no código
-
-- `rh_range` aceita porcentagem ou fração e é normalizado para fração.
-- A zona pode ser declarada por geometria explícita (`vertices`) ou por faixas semânticas (`t_range` + `rh_range`).
-
-### Inferência controlada
-
-- `follow_rh: true` sugere que o contorno deve seguir curvas de umidade relativa, e não um retângulo bruto.
-
-### Não foi possível validar
-
-- O algoritmo exato que transforma `t_range` + `rh_range` em polígono final.
-
-## Erros comuns
-
-- Misturar coordenadas de `vertices` com a ideia de `rh_range`: `vertices` aparenta esperar coordenadas finais do gráfico, enquanto `rh_range` ainda está em umidade relativa.
+- `rh_range` e `label_rh` aceitam porcentagem ou fração e são normalizados internamente.
+- `follow_rh: true` faz o contorno seguir curvas de umidade relativa.
+- Use `zones` quando a geometria da região já é conhecida antes do cálculo de qualquer índice.
 
 ---
 
@@ -92,47 +72,90 @@ Zona semântica definida por um intervalo de um índice calculado, e não por ge
 
 ## Para que serve
 
-Serve para classificar o gráfico por faixas de índice, como conforto, alerta ou perigo.
+Serve para pintar regiões do gráfico onde um índice fica dentro de uma faixa numérica, por exemplo:
+
+```text
+68 <= ITU <= 72
+```
+
+Nesse caso, o psychChart avalia o índice em todo o domínio físico válido do gráfico e preenche a região onde o valor calculado satisfaz o intervalo definido.
 
 ## Parâmetros disponíveis
-
-### Confirmado no código
 
 - `index`
 - `name`
 - `range`
 - `color`
+- `facecolor`
+- `edgecolor`
+- `linewidth`
 - `alpha`
+- `show_label`
+- `label`
+- `label_position`
+- `label_t`
+- `label_rh`
+- `label_color`
+- `label_fontsize`
+- `label_fontweight`
+- `label_rotation`
+- `label_bbox`
 - `parameters`
 
 ## Valores aceitos
 
-- `index`, `name`, `color`: texto.
-- `range`: par numérico.
-- `alpha`: número.
-- `parameters`: objeto.
+- `index`, `name`, `color`, `facecolor`, `edgecolor`, `label`, `label_color`, `label_fontweight`: texto.
+- `range`: par numérico com limite inferior menor que limite superior.
+- `alpha`, `linewidth`, `label_fontsize`, `label_rotation`, `label_t`, `label_rh`: número.
+- `show_label`: booleano.
+- `label_position`: `auto` ou `manual`.
+- `parameters`, `label_bbox`: objeto.
 
-## Exemplo de uso
+## Exemplo com rótulo interno automático
 
 ```yaml
 index_zones:
   - index: ITU
-    name: comfort
-    range: [20, 72]
-    color: green
-    alpha: 0.25
+    name: "ITU comfort zone"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    alpha: 0.38
+    linewidth: 1.1
+    show_label: true
+    label: "ITU"
+    label_position: auto
+    label_color: "#2F3A2F"
+    label_fontsize: 12
+    label_fontweight: "bold"
+    label_rotation: 72
 ```
 
-## Observações importantes
+## Exemplo com rótulo interno manual
 
-### Confirmado no código
-
-- `parameters` existe para índices parametrizados.
-
-### Não foi possível validar
-
-- Como a região espacial correspondente a `range` é calculada no gráfico.
+```yaml
+index_zones:
+  - index: ITU
+    name: "ITU comfort zone"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    alpha: 0.38
+    linewidth: 1.1
+    show_label: true
+    label: "ITU"
+    label_position: manual
+    label_t: 25.5
+    label_rh: 55
+    label_color: "#2F3A2F"
+    label_fontsize: 12
+    label_fontweight: "bold"
+    label_rotation: 72
+```
 
 ## Erros comuns
 
-- Definir `index_zones` sem que o índice correspondente exista no runtime.
+- Usar `zones` para representar uma faixa de ITU. Para isso, use `index_zones`.
+- Usar `label_position: manual` sem informar `label_t` e `label_rh`.
+- Definir `range` com limite inferior maior ou igual ao limite superior.
+- Definir `index_zones` com um índice que não existe no registry.

--- a/docs/psychchart_user_docs_markdown_final/psychchart_docs_final/docs/config/zones.md
+++ b/docs/psychchart_user_docs_markdown_final/psychchart_docs_final/docs/config/zones.md
@@ -1,32 +1,16 @@
 # `zones` e `index_zones`
 
-## O que é
+O psychChart possui dois mecanismos complementares para desenhar regiões no gráfico psicrométrico.
 
-Há dois tipos de zonas nos arquivos enviados:
+`zones` representa zonas geométricas declaradas diretamente pelo usuário em temperatura e umidade relativa. Esse mecanismo é adequado para envelopes experimentais, regiões manuais, áreas de projeto ou polígonos definidos por vértices.
 
-- `zones`: zonas geométricas
-- `index_zones`: zonas semânticas baseadas em faixas de índice
-
-## Para que serve
-
-### `zones`
-
-Usadas para representar regiões como:
-
-- conforto
-- risco
-- envelopes operacionais
-- regiões definidas manualmente
-
-### `index_zones`
-
-Usadas para colorir áreas do gráfico conforme intervalos de um índice, como `ITU` ou `TE`.
-
----
+`index_zones` representa zonas derivadas de intervalos de um índice calculado, como `ITU`, `HLI`, `BGHI` ou qualquer outro índice registrado. Nesse caso, a geometria da região não é fornecida manualmente. O psychChart avalia o índice no domínio psicrométrico válido e pinta os pontos em que o valor calculado cai dentro do intervalo configurado.
 
 ## `zones`
 
-### Parâmetros disponíveis
+Use `zones` quando a região já é conhecida geometricamente.
+
+Parâmetros aceitos:
 
 - `name`
 - `vertices`
@@ -37,17 +21,16 @@ Usadas para colorir áreas do gráfico conforme intervalos de um índice, como `
 - `facecolor`
 - `linewidth`
 - `alpha`
+- `show_label`
+- `label`
+- `label_t`
+- `label_rh`
+- `label_color`
+- `label_fontsize`
+- `label_rotation`
+- `label_bbox`
 
-### Valores aceitos
-
-- `vertices`: lista de pares numéricos
-- `t_range`: par numérico
-- `rh_range`: par numérico em fração ou porcentagem
-- `follow_rh`: booleano
-- `edgecolor`, `facecolor`: texto
-- `linewidth`, `alpha`: número
-
-### Exemplo de uso
+Exemplo:
 
 ```yaml
 zones:
@@ -57,63 +40,129 @@ zones:
     follow_rh: true
     edgecolor: "green"
     facecolor: "lightgreen"
+    linewidth: 1.5
     alpha: 0.3
+    show_label: true
+    label: "Comfort"
+    label_t: 22
+    label_rh: 55
 ```
 
-### Observações importantes
+Observações:
 
-#### Confirmado no código
-
-- `rh_range` é normalizado para fração
-- o renderer geométrico aceita:
-  - polígono explícito por `vertices`
-  - zona por `t_range + rh_range`
-  - zona com bordas seguindo curvas de umidade relativa quando `follow_rh = true`
-
-#### Inferência controlada
-
-- `follow_rh: true` é a forma mais coerente para zonas que você quer alinhar à física psicrométrica, e não a um retângulo bruto no plano
-
----
+- `rh_range` e `label_rh` aceitam fração ou porcentagem.
+- `follow_rh: true` faz as bordas seguirem curvas de umidade relativa.
+- `vertices` devem ser fornecidos em coordenadas de temperatura e umidade relativa.
 
 ## `index_zones`
 
-### Parâmetros disponíveis
+Use `index_zones` quando a região deve ser definida por uma faixa numérica de um índice calculado. Esse é o mecanismo recomendado para pintar uma área de ITU, por exemplo uma faixa entre 68 e 72.
+
+Parâmetros aceitos:
 
 - `index`
 - `name`
 - `range`
 - `color`
+- `facecolor`
+- `edgecolor`
+- `linewidth`
 - `alpha`
+- `show_label`
+- `label`
+- `label_position`
+- `label_t`
+- `label_rh`
+- `label_color`
+- `label_fontsize`
+- `label_fontweight`
+- `label_rotation`
+- `label_bbox`
 - `parameters`
 
-### Valores aceitos
+`color` é mantido como alias legado para a cor de preenchimento. Em novas configurações, prefira `facecolor`.
 
-- `index`: texto
-- `name`: texto
-- `range`: par numérico
-- `color`: texto
-- `alpha`: número
-- `parameters`: dicionário
+`label_position` aceita dois valores: `auto` e `manual`. Com `auto`, o psychChart estima uma posição interna representativa da região pintada. Com `manual`, use também `label_t` e `label_rh`.
 
-### Exemplo de uso
+Exemplo com rótulo automático:
 
 ```yaml
 index_zones:
   - index: ITU
-    name: "danger"
-    range: [78, 84]
-    color: "orange"
-    alpha: 0.25
+    name: "ITU comfort zone"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    alpha: 0.38
+    linewidth: 1.1
+    show_label: true
+    label: "ITU"
+    label_position: auto
+    label_color: "#2F3A2F"
+    label_fontsize: 12
+    label_fontweight: "bold"
+    label_rotation: 72
 ```
 
-### Observações importantes
+Exemplo com rótulo manual:
 
-#### Confirmado no código
+```yaml
+index_zones:
+  - index: ITU
+    name: "ITU comfort zone"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    alpha: 0.38
+    linewidth: 1.1
+    show_label: true
+    label: "ITU"
+    label_position: manual
+    label_t: 25.5
+    label_rh: 55
+    label_color: "#2F3A2F"
+    label_fontsize: 12
+    label_fontweight: "bold"
+    label_rotation: 72
+```
 
-- o renderer de `index_zones` cria uma máscara booleana da faixa e desenha uma região preenchida com `contourf`
-- o nome da zona também aparece como texto no canto superior esquerdo do gráfico, em coordenadas do eixo
+Exemplo completo mínimo:
 
-#### Não foi possível validar
+```yaml
+chart:
+  t_min: 10
+  t_max: 45
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+  output: "index_zone_itu_labeled.png"
 
-- a estratégia completa de clipping físico dessas zonas em todos os cenários
+indexes:
+  - index: ITU
+    render:
+      isolines:
+        levels: [68, 72, 78, 84]
+        color: "#111111"
+        linewidth: 0.9
+        label: true
+        label_fmt: "ITU {value:.0f}"
+
+index_zones:
+  - index: ITU
+    name: "ITU comfort zone"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    alpha: 0.38
+    linewidth: 1.1
+    show_label: true
+    label: "ITU"
+    label_position: auto
+    label_rotation: 72
+```
+
+## Escolha correta
+
+Use `zones` para áreas geométricas ou experimentais.
+
+Use `index_zones` para áreas calculadas por índice. Para ITU, HLI ou outros índices, essa é a forma correta, porque a área final é calculada a partir do campo do índice e não a partir de uma aproximação retangular.

--- a/examples/index_zone_itu_labeled.yaml
+++ b/examples/index_zone_itu_labeled.yaml
@@ -1,0 +1,79 @@
+# -----------------------------------------------------------------------------
+# ITU-derived labeled zone
+# -----------------------------------------------------------------------------
+# This example shows how to paint a psychrometric region from an interval of a
+# computed index. Unlike a geometric `zones` polygon, this region is derived
+# from the ITU scalar field itself: every physically valid point where
+# 68 <= ITU <= 72 is filled and labeled inside the chart.
+# -----------------------------------------------------------------------------
+
+chart:
+  t_min: 10
+  t_max: 45
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+
+  xlabel: "Dry-bulb temperature (°C)"
+  ylabel: "Humidity ratio (kg/kg dry air)"
+  title: "Psychrometric chart with labeled ITU-derived zone"
+  output: "index_zone_itu_labeled.png"
+  dpi: 300
+  figsize: [16, 9]
+
+  show_tw_grid: true
+  tw_grid_style:
+    color: "#8a8a8a"
+    linewidth: 0.45
+    linestyle: "-"
+    alpha: 0.22
+
+isolines:
+  relative_humidity:
+    enabled: true
+    values: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    color: "#555555"
+    linestyle: "--"
+    linewidth: 0.7
+    alpha: 0.55
+    labels: true
+    label_fontsize: 7
+    label_fmt: "{value:.0%}"
+
+indexes:
+  - index: ITU
+    label: "Temperature-Humidity Index (ITU)"
+    render:
+      isolines:
+        levels: [68, 72, 78, 84]
+        style: "-"
+        color: "#111111"
+        linewidth: 0.9
+        alpha: 0.85
+        label: true
+        label_fontsize: 8
+        label_fmt: "ITU {value:.0f}"
+
+index_zones:
+  - index: ITU
+    name: "ITU comfort zone"
+    range: [68, 72]
+
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    alpha: 0.38
+    linewidth: 1.1
+
+    show_label: true
+    label: "ITU"
+    label_position: auto
+    label_color: "#2F3A2F"
+    label_fontsize: 12
+    label_fontweight: "bold"
+    label_rotation: 72
+
+zones: []
+points: []
+data_layers: []
+observations: []
+temporal_overlays: []

--- a/src/psychchart/config/zones.py
+++ b/src/psychchart/config/zones.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from .base import StrictModel
 from .utils import normalize_rh
@@ -116,15 +116,104 @@ class Zone(StrictModel):
 
 class IndexZone(StrictModel):
     """
-    Definition of a semantic zone derived from an index range.
+    Definition of a semantic zone derived from an index interval.
 
-    This model describes regions obtained from intervals of a computed scalar
-    index such as ITU, THI, HLI, or another registered indicator.
+    An index zone represents the subset of the psychrometric domain where a
+    computed scalar index lies within a prescribed numerical interval. It is
+    therefore different from a geometric :class:`Zone`: its shape is not
+    declared by vertices, but derived from the index field evaluated over the
+    physically valid chart domain.
+
+    Parameters
+    ----------
+    index : str
+        Registered index name, for example ``ITU`` or ``HLI``.
+    name : str
+        Semantic identifier and default label text.
+    range : tuple of float
+        Closed numerical interval ``[min, max]`` used to select the index
+        region to be filled.
+    color : str, optional
+        Legacy fill color alias preserved for older YAML files.
+    facecolor : str, optional
+        Fill color. Takes precedence over ``color`` when provided.
+    edgecolor : str, optional
+        Optional contour color for the selected index interval.
+    linewidth : float, default=0.0
+        Optional contour-line width. Set to zero to disable the outline.
+    alpha : float, default=0.3
+        Fill opacity.
+    show_label : bool, default=False
+        Whether to draw a label inside the index-derived region.
+    label : str, optional
+        Text drawn inside the region. If omitted, ``name`` is used.
+    label_position : str, default="auto"
+        Label placement strategy. ``auto`` estimates a representative internal
+        point from the selected mask. ``manual`` requires ``label_t`` and
+        ``label_rh``.
+    label_t, label_rh : float, optional
+        Manual label position in ``(T, RH)`` coordinates. ``label_rh`` accepts
+        either fraction or percent and is normalized to fraction internally.
+    label_color : str, optional
+        Text color. Defaults to ``edgecolor`` or ``color`` when omitted.
+    label_fontsize : float, default=9.0
+        Label font size.
+    label_fontweight : str, optional
+        Matplotlib-compatible text weight, for example ``bold``.
+    label_rotation : float, default=0.0
+        Label rotation in degrees.
+    label_bbox : dict, optional
+        Matplotlib-compatible annotation bounding-box dictionary.
+    parameters : dict, optional
+        Reserved for parameterized index definitions.
     """
 
     index: str
     name: str
     range: Tuple[float, float]
+
     color: str = "gray"
+    facecolor: Optional[str] = None
+    edgecolor: Optional[str] = None
+    linewidth: float = 0.0
     alpha: float = 0.3
+
+    show_label: bool = False
+    label: Optional[str] = None
+    label_position: str = "auto"
+    label_t: Optional[float] = None
+    label_rh: Optional[float] = None
+    label_color: Optional[str] = None
+    label_fontsize: float = 9.0
+    label_fontweight: Optional[str] = None
+    label_rotation: float = 0.0
+    label_bbox: Optional[Dict[str, Any]] = None
+
     parameters: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("label_rh", mode="before")
+    @classmethod
+    def validate_label_rh(cls, value: Any) -> float | None:
+        """Normalize optional label relative humidity to fraction."""
+        if value is None:
+            return value
+        return normalize_rh(value)
+
+    @model_validator(mode="after")
+    def validate_range_and_label(self) -> "IndexZone":
+        """Validate interval ordering and manual label placement."""
+        lower, upper = self.range
+        if lower >= upper:
+            raise ValueError("IndexZone 'range' must satisfy lower < upper")
+
+        if self.label_position not in {"auto", "manual"}:
+            raise ValueError("IndexZone 'label_position' must be 'auto' or 'manual'")
+
+        if self.label_position == "manual" and (
+            self.label_t is None or self.label_rh is None
+        ):
+            raise ValueError(
+                "Manual IndexZone label placement requires both 'label_t' and 'label_rh'"
+            )
+
+        return self

--- a/src/psychchart/plot/indexes.py
+++ b/src/psychchart/plot/indexes.py
@@ -1,40 +1,24 @@
-"""
-Index rendering utilities for psychrometric charts.
-
-Pure rendering layer.
-
-Responsibilities:
-- Receive precomputed index layers (via render/)
-- Draw them using matplotlib
-
-Non-responsibilities:
-- No index computation
-- No grid building
-- No psychrometric transformations
-"""
+"""Index rendering utilities for psychrometric charts."""
 
 from __future__ import annotations
-import numpy as np
-from matplotlib.pyplot import get_cmap
-from matplotlib.axes import Axes
-from matplotlib.patches import PathPatch
-from matplotlib.colors import ListedColormap, BoundaryNorm, Normalize
 
-from psychchart.render.build_index_field import build_index_field
-from psychchart.plot.index_profiles import get_index_profile
-from psychchart.indexes.registry import INDEX_REGISTRY
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.colors import BoundaryNorm, ListedColormap, Normalize
+from matplotlib.pyplot import get_cmap
+
+from psychchart.config import FieldRenderConfig, IsolineRenderConfig
 from psychchart.indexes.base import BaseIndex
+from psychchart.indexes.registry import INDEX_REGISTRY
+from psychchart.plot.index_profiles import get_index_profile
+from psychchart.render.build_index_field import build_index_field
+
 from .layers import ZORDER
 from .operational_zones import draw_operational_zones
 
 
-# =============================================================================
-# Helpers
-# =============================================================================
 def _resolve_index(index) -> type[BaseIndex]:
-    """
-    Resolve index from string or class.
-    """
+    """Resolve an index identifier to its registered index class."""
     if isinstance(index, str):
         if index not in INDEX_REGISTRY:
             raise ValueError(f"Unknown index '{index}'")
@@ -47,13 +31,7 @@ def _resolve_index(index) -> type[BaseIndex]:
 
 
 def _get_index_layer(chart, index):
-    """
-    Resolve index and safely build its scalar field layer.
-
-    Returns
-    -------
-    (index_cls, layer) or (index_cls, None)
-    """
+    """Resolve an index and build/cache its scalar field layer."""
     if not hasattr(chart, "_index_cache"):
         chart._index_cache = {}
 
@@ -68,17 +46,11 @@ def _get_index_layer(chart, index):
         return index_cls, None
 
     chart._index_cache[index] = layer
-
     return index_cls, layer
 
 
-# =============================================================================
-# Continuous index fields (heatmaps)
-# =============================================================================
 def _draw_index_field(chart, ax: Axes, layer, cfg):
-    """
-    Render a continuous psychrometric index field as a background layer.
-    """
+    """Render a continuous psychrometric index field."""
     profile = get_index_profile(cfg.index)
     field_cfg = (
         cfg.render.field
@@ -95,10 +67,7 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
     if levels:
         if cfg.cmap:
             cmap = cfg.cmap
-            norm = BoundaryNorm(
-                levels,
-                get_cmap(cmap).N if isinstance(cmap, str) else cmap.N,
-            )
+            norm = BoundaryNorm(levels, get_cmap(cmap).N if isinstance(cmap, str) else cmap.N)
         elif colors:
             cmap = ListedColormap(colors)
             norm = BoundaryNorm(levels, cmap.N)
@@ -108,6 +77,8 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
     if norm is None and (cfg.vmin is not None or cfg.vmax is not None):
         norm = Normalize(vmin=cfg.vmin, vmax=cfg.vmax)
 
+    alpha = 1.0 if field_cfg.alpha is None else field_cfg.alpha
+
     if levels:
         artist = ax.contourf(
             layer.X,
@@ -116,7 +87,7 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
             levels=levels,
             cmap=cmap,
             norm=norm,
-            alpha=field_cfg.alpha,
+            alpha=alpha,
             zorder=ZORDER["index_field"],
             extend="max",
         )
@@ -128,7 +99,7 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
             shading="auto",
             cmap=cmap,
             norm=norm,
-            alpha=field_cfg.alpha,
+            alpha=alpha,
             zorder=ZORDER["index_field"],
         )
 
@@ -137,26 +108,16 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
 
         if profile and profile.labels and levels:
             n_intervals = len(levels) - 1
-            n_labels = len(profile.labels)
-
-            if n_labels == n_intervals:
-                mids = [
-                    0.5 * (levels[i] + levels[i + 1])
-                    for i in range(n_intervals)
-                ]
+            if len(profile.labels) == n_intervals:
+                mids = [0.5 * (levels[i] + levels[i + 1]) for i in range(n_intervals)]
                 cbar.set_ticks(mids)
                 cbar.set_ticklabels(profile.labels)
 
         cbar.set_label(cfg.label or cfg.index)
 
 
-# =============================================================================
-# Index isolines
-# =============================================================================
 def _draw_index_isolines(chart, ax: Axes, layer, cfg) -> None:
-    """
-    Draw contour lines (isolines) of a psychrometric/bioclimatic index.
-    """
+    """Draw contour lines of a psychrometric or bioclimatic index."""
     profile = get_index_profile(cfg.index)
     iso_cfg = (
         cfg.render.isolines
@@ -164,16 +125,9 @@ def _draw_index_isolines(chart, ax: Axes, layer, cfg) -> None:
         else IsolineRenderConfig()
     )
 
-    levels = (
-        iso_cfg.levels
-        or cfg.levels
-        or (profile.levels if profile else None)
-    )
-
+    levels = iso_cfg.levels or cfg.levels or (profile.levels if profile else None)
     if not levels:
         return
-
-    line_color = iso_cfg.color or "black"
 
     cs = ax.contour(
         layer.X,
@@ -182,14 +136,13 @@ def _draw_index_isolines(chart, ax: Axes, layer, cfg) -> None:
         levels=levels,
         linestyles=iso_cfg.style,
         linewidths=iso_cfg.linewidth,
-        colors=line_color,
+        colors=iso_cfg.color or "black",
         alpha=iso_cfg.alpha,
         zorder=ZORDER["isolines"],
     )
 
     if iso_cfg.label:
         template = iso_cfg.label_fmt or "{index} = {value:.0f}"
-
         ax.clabel(
             cs,
             fmt=lambda v: template.format(index=cfg.index, value=v),
@@ -197,70 +150,124 @@ def _draw_index_isolines(chart, ax: Axes, layer, cfg) -> None:
         )
 
 
-# =============================================================================
-# Index zones
-# =============================================================================
-def _draw_index_zone(chart, ax: Axes, zone):
-    index_cls = _resolve_index(zone.index)
+def _index_zone_mask(layer, zone) -> np.ndarray:
+    """Return the finite boolean mask selected by an index-zone interval."""
+    lower, upper = zone.range
+    return np.isfinite(layer.Z) & (layer.Z >= lower) & (layer.Z <= upper)
 
-    try:
-        layer = build_index_field(index_cls, chart.cfg, chart.psych)
-    except ValueError:
+
+def _index_zone_facecolor(zone) -> str:
+    """Return the fill color for an index zone."""
+    return zone.facecolor or zone.color or "gray"
+
+
+def _index_zone_label_position(chart, zone, layer, mask: np.ndarray) -> tuple[float, float] | None:
+    """Return a chart-coordinate label position for an index-derived zone."""
+    if zone.label_t is not None and zone.label_rh is not None:
+        label_w = chart.psych.humidity_ratio(zone.label_t, zone.label_rh, chart.cfg.pressure)
+        return float(zone.label_t), float(label_w)
+
+    if zone.label_position == "manual":
+        return None
+
+    x_vals = layer.X[mask]
+    y_vals = layer.Y[mask]
+
+    if x_vals.size == 0:
+        return None
+
+    x0 = float(np.nanmedian(x_vals))
+    y0 = float(np.nanmedian(y_vals))
+    dist2 = (x_vals - x0) ** 2 + (y_vals - y0) ** 2
+    i = int(np.nanargmin(dist2))
+
+    return float(x_vals[i]), float(y_vals[i])
+
+
+def _draw_index_zone_label(ax: Axes, chart, zone, layer, mask: np.ndarray) -> None:
+    """Draw an optional label inside an index-derived region."""
+    if not zone.show_label:
         return
 
-    if not hasattr(zone, "range") or len(zone.range) != 2:
-        raise ValueError(f"Invalid zone range for index '{zone.index}'")
+    text = zone.label or zone.name
+    if not text:
+        return
 
-    mask = (layer.Z >= zone.range[0]) & (layer.Z <= zone.range[1])
+    position = _index_zone_label_position(chart, zone, layer, mask)
+    if position is None:
+        return
+
+    bbox = zone.label_bbox
+    if bbox is None:
+        bbox = {
+            "boxstyle": "round,pad=0.20",
+            "facecolor": "white",
+            "edgecolor": "none",
+            "alpha": 0.0,
+        }
+
+    ax.annotate(
+        text,
+        xy=position,
+        ha="center",
+        va="center",
+        color=zone.label_color or zone.edgecolor or zone.color or "black",
+        fontsize=zone.label_fontsize,
+        fontweight=zone.label_fontweight,
+        rotation=zone.label_rotation,
+        bbox=bbox,
+        zorder=ZORDER["zone_edge"] + 1,
+    )
+
+
+def _draw_index_zone(chart, ax: Axes, zone) -> None:
+    """Draw a filled and optionally labeled region derived from an index interval."""
+    _, layer = _get_index_layer(chart, zone.index)
+    if layer is None:
+        return
+
+    mask = _index_zone_mask(layer, zone)
+    if not np.any(mask):
+        return
+
+    mask_field = np.where(mask, 1.0, np.nan)
 
     ax.contourf(
         layer.X,
         layer.Y,
-        mask,
-        levels=[0.5, 1],
-        colors=[zone.color],
+        mask_field,
+        levels=[0.5, 1.5],
+        colors=[_index_zone_facecolor(zone)],
         alpha=zone.alpha,
         zorder=ZORDER["index_zone"],
     )
 
-    if not hasattr(chart, "_index_zone_counter"):
-        chart._index_zone_counter = 0
+    if zone.edgecolor and zone.linewidth > 0:
+        ax.contour(
+            layer.X,
+            layer.Y,
+            mask.astype(float),
+            levels=[0.5],
+            colors=[zone.edgecolor],
+            linewidths=zone.linewidth,
+            zorder=ZORDER["zone_edge"],
+        )
 
-    ax.text(
-        0.01,
-        0.99 - 0.05 * chart._index_zone_counter,
-        f"{zone.index}: {zone.name}",
-        transform=ax.transAxes,
-        fontsize=9,
-        verticalalignment="top",
-        zorder=ZORDER["zone_edge"],
-    )
-
-    chart._index_zone_counter += 1
+    _draw_index_zone_label(ax, chart, zone, layer, mask)
 
 
 def _draw_operational_overlays(chart, ax: Axes) -> None:
-    """
-    Draw all configured operational overlays.
-
-    Operational overlays are intentionally dispatched from the index rendering
-    stage because they are gridded semantic fields over the same psychrometric
-    domain as ITU/HLI/BGHI fields. Their z-order remains fully controlled by the
-    overlay configuration, so they can be placed behind or above index fields.
-    """
+    """Draw all configured operational overlays."""
     overlays = getattr(chart, "operational_overlays", None) or []
 
     for overlay_cfg in overlays:
         draw_operational_zones(ax, chart, overlay_cfg)
 
 
-# =============================================================================
-# Public dispatchers
-# =============================================================================
 def draw_indexes(chart, ax):
+    """Draw all configured index fields and isolines."""
     for cfg in chart.indexes:
-        index_cls, layer = _get_index_layer(chart, cfg.index)
-
+        _, layer = _get_index_layer(chart, cfg.index)
         if layer is None:
             continue
 
@@ -274,6 +281,7 @@ def draw_indexes(chart, ax):
 
 
 def draw_index_zones(chart, ax: Axes) -> None:
+    """Draw all configured index-derived zones."""
     if not getattr(chart, "index_zones", None):
         return
 

--- a/tests/test_index_zones.py
+++ b/tests/test_index_zones.py
@@ -5,6 +5,21 @@ from psychchart import PsychChart, load_chart_config
 from psychchart.config import AppConfig, IndexZone
 
 
+def _minimal_chart_config():
+    """Return the required ChartConfig fields for root-model validation tests."""
+    return {
+        "t_min": 10,
+        "t_max": 45,
+        "y_min": 0.0,
+        "y_max": 0.035,
+        "pressure": 101325,
+        "xlabel": "Dry-bulb temperature (°C)",
+        "ylabel": "Humidity ratio (kg/kg dry air)",
+        "output": "index_zone_test.png",
+        "dpi": 150,
+    }
+
+
 def test_index_zone_accepts_styling_and_internal_label_options():
     """IndexZone should validate the full style and label schema."""
     zone = IndexZone(
@@ -55,12 +70,7 @@ def test_app_config_accepts_labeled_index_zone():
     """Root configuration should accept labeled index-derived zones."""
     cfg = AppConfig.model_validate(
         {
-            "chart": {
-                "t_min": 10,
-                "t_max": 45,
-                "y_min": 0.0,
-                "y_max": 0.035,
-            },
+            "chart": _minimal_chart_config(),
             "index_zones": [
                 {
                     "index": "ITU",

--- a/tests/test_index_zones.py
+++ b/tests/test_index_zones.py
@@ -1,0 +1,131 @@
+import matplotlib.pyplot as plt
+import pytest
+
+from psychchart import PsychChart, load_chart_config
+from psychchart.config import AppConfig, IndexZone
+
+
+def test_index_zone_accepts_styling_and_internal_label_options():
+    """IndexZone should validate the full style and label schema."""
+    zone = IndexZone(
+        index="ITU",
+        name="comfort",
+        range=(68, 72),
+        facecolor="#A8E67A",
+        edgecolor="#5B8F3A",
+        linewidth=1.1,
+        alpha=0.38,
+        show_label=True,
+        label="ITU",
+        label_position="manual",
+        label_t=25.5,
+        label_rh=55,
+        label_color="#2F3A2F",
+        label_fontsize=12,
+        label_fontweight="bold",
+        label_rotation=72,
+    )
+
+    assert zone.range == (68, 72)
+    assert zone.label_rh == pytest.approx(0.55)
+    assert zone.facecolor == "#A8E67A"
+    assert zone.show_label is True
+
+
+def test_index_zone_rejects_invalid_interval_order():
+    """IndexZone intervals must have lower < upper."""
+    with pytest.raises(ValueError):
+        IndexZone(index="ITU", name="invalid", range=(72, 68))
+
+
+def test_index_zone_manual_label_requires_coordinates():
+    """Manual label placement must be explicit and reproducible."""
+    with pytest.raises(ValueError):
+        IndexZone(
+            index="ITU",
+            name="comfort",
+            range=(68, 72),
+            show_label=True,
+            label_position="manual",
+            label_t=25.0,
+        )
+
+
+def test_app_config_accepts_labeled_index_zone():
+    """Root configuration should accept labeled index-derived zones."""
+    cfg = AppConfig.model_validate(
+        {
+            "chart": {
+                "t_min": 10,
+                "t_max": 45,
+                "y_min": 0.0,
+                "y_max": 0.035,
+            },
+            "index_zones": [
+                {
+                    "index": "ITU",
+                    "name": "ITU comfort zone",
+                    "range": [68, 72],
+                    "facecolor": "#A8E67A",
+                    "edgecolor": "#5B8F3A",
+                    "linewidth": 1.1,
+                    "alpha": 0.38,
+                    "show_label": True,
+                    "label": "ITU",
+                    "label_position": "auto",
+                    "label_color": "#2F3A2F",
+                    "label_fontsize": 12,
+                    "label_fontweight": "bold",
+                    "label_rotation": 72,
+                }
+            ],
+        }
+    )
+
+    assert len(cfg.index_zones) == 1
+    assert cfg.index_zones[0].label == "ITU"
+
+
+def test_labeled_index_zone_render_smoke(tmp_path):
+    """Rendering an index-zone fill with an internal label should not fail."""
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 45
+  y_min: 0.0
+  y_max: 0.035
+  output: index_zone_smoke.png
+
+indexes:
+  - index: ITU
+    render:
+      isolines:
+        levels: [68, 72]
+        color: "black"
+        linewidth: 0.8
+        label: true
+        label_fmt: "ITU {value:.0f}"
+
+index_zones:
+  - index: ITU
+    name: "ITU comfort zone"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    linewidth: 1.0
+    alpha: 0.35
+    show_label: true
+    label: "ITU"
+    label_position: auto
+    label_color: "#2F3A2F"
+    label_fontsize: 10
+    label_fontweight: bold
+    label_rotation: 70
+"""
+    cfg_file = tmp_path / "index_zone.yaml"
+    cfg_file.write_text(yaml)
+
+    data = load_chart_config(cfg_file)
+    chart = PsychChart(**data)
+    chart.draw()
+    plt.close(chart.fig)


### PR DESCRIPTION
## Summary

This PR completes the `index_zones` feature so psychChart can paint regions derived from intervals of computed indexes and place labels inside those regions.

Changes included:
- expanded `IndexZone` with fill, outline, and label options;
- preserved `color` as a legacy fill-color alias;
- added automatic and manual internal label placement;
- added validation for intervals and manual label coordinates;
- updated index-zone rendering to use filled masks, optional contours, and internal labels;
- added an ITU example YAML;
- updated user documentation;
- added pytest coverage for validation and rendering smoke behavior.

Files changed:
- `src/psychchart/config/zones.py`
- `src/psychchart/plot/indexes.py`
- `tests/test_index_zones.py`
- `examples/index_zone_itu_labeled.yaml`
- zone documentation files

Validation:
- Branch diff was checked against `main`.
- Dedicated tests were added for the new feature and are ready for CI execution.