### PR TITLE
Render semantic index labels inside field layers

### DIFF
--- a/src/psychchart/config/indexes.py
+++ b/src/psychchart/config/indexes.py
@@ -21,13 +21,20 @@ from .base import StrictModel
 
 
 class FieldLabelPosition(StrictModel):
-    """Manual position for one in-chart field label."""
+    """Manual position for one in-chart field label.
+
+    Positions may be declared directly in chart coordinates ``T x W`` using
+    ``t``/``w`` or in the more intuitive ``T x RH`` form using ``t``/``rh``.
+    Relative humidity may be provided either as a fraction in ``[0, 1]`` or as
+    a percentage in ``[0, 100]``.
+    """
 
     label: Optional[str] = None
     x: Optional[float] = None
     y: Optional[float] = None
     t: Optional[float] = None
     w: Optional[float] = None
+    rh: Optional[float] = None
     rotation: Optional[float] = None
 
 
@@ -84,6 +91,10 @@ class IndexConfig(BaseModel):
                 labels: true
                 label_fontsize: 24
                 label_rotation: -18
+                label_positions:
+                  - label: "Comfort"
+                    t: 14
+                    rh: 60
 
     ``levels``, ``colors`` and ``labels`` are index semantics. They do not live
     under ``render.field``. The nested ``render.field.labels`` flag only controls

--- a/src/psychchart/config/indexes.py
+++ b/src/psychchart/config/indexes.py
@@ -5,10 +5,10 @@ This module defines typed configuration models used to describe computed
 psychrometric or thermal indexes.
 
 Index configuration is split into semantic settings (``levels``, ``colors`` and
-``labels``) and rendering settings (field opacity, colorbar visibility and
-isoline style). This lets packaged profiles provide defaults while allowing a
-user YAML file to override the semantic representation without changing Python
-code.
+``labels``) and rendering settings (field opacity, colorbar visibility, in-chart
+label visibility and isoline style). This lets packaged profiles provide
+defaults while allowing a user YAML file to override the semantic
+representation without changing Python code.
 """
 
 from __future__ import annotations
@@ -20,11 +20,30 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from .base import StrictModel
 
 
+class FieldLabelPosition(StrictModel):
+    """Manual position for one in-chart field label."""
+
+    label: Optional[str] = None
+    x: Optional[float] = None
+    y: Optional[float] = None
+    t: Optional[float] = None
+    w: Optional[float] = None
+    rotation: Optional[float] = None
+
+
 class FieldRenderConfig(StrictModel):
     """Rendering options for a continuous index field."""
 
     alpha: Optional[float] = None
     colorbar: Optional[bool] = None
+
+    labels: Optional[bool] = None
+    label_fontsize: Optional[float] = None
+    label_color: Optional[str] = None
+    label_alpha: Optional[float] = None
+    label_fontweight: Optional[str] = None
+    label_rotation: Optional[float] = None
+    label_positions: Optional[List[FieldLabelPosition]] = None
 
 
 class IsolineRenderConfig(StrictModel):
@@ -61,10 +80,14 @@ class IndexConfig(BaseModel):
             render:
               field:
                 alpha: 0.65
-                colorbar: true
+                colorbar: false
+                labels: true
+                label_fontsize: 24
+                label_rotation: -18
 
     ``levels``, ``colors`` and ``labels`` are index semantics. They do not live
-    under ``render.field``.
+    under ``render.field``. The nested ``render.field.labels`` flag only controls
+    whether those semantic labels are drawn inside the diagram.
     """
 
     model_config = ConfigDict(

--- a/src/psychchart/plot/indexes.py
+++ b/src/psychchart/plot/indexes.py
@@ -73,6 +73,71 @@ def _get_index_layer(chart, index):
     return index_cls, layer
 
 
+def _resolve_field_label_position(position, fallback_label: str) -> tuple[float | None, float | None, str, float | None]:
+    """
+    Normalize one manual label position.
+    """
+    x = position.x if position.x is not None else position.t
+    y = position.y if position.y is not None else position.w
+    label = position.label or fallback_label
+    return x, y, label, position.rotation
+
+
+def _draw_index_field_labels(ax: Axes, field_cfg, levels, labels) -> None:
+    """
+    Draw semantic class labels inside the psychrometric diagram.
+    """
+    if not field_cfg.labels or not levels or not labels:
+        return
+
+    n_intervals = len(levels) - 1
+    if len(labels) != n_intervals:
+        return
+
+    fontsize = field_cfg.label_fontsize or 24.0
+    color = field_cfg.label_color or "black"
+    alpha = field_cfg.label_alpha if field_cfg.label_alpha is not None else 0.82
+    fontweight = field_cfg.label_fontweight or "normal"
+    default_rotation = field_cfg.label_rotation if field_cfg.label_rotation is not None else -18.0
+    zorder = ZORDER["index_field"] + 0.5
+
+    manual_positions = field_cfg.label_positions or []
+
+    for i, label in enumerate(labels):
+        x = None
+        y = None
+        rotation = default_rotation
+
+        if i < len(manual_positions):
+            x, y, label, manual_rotation = _resolve_field_label_position(
+                manual_positions[i],
+                label,
+            )
+            if manual_rotation is not None:
+                rotation = manual_rotation
+
+        if x is None:
+            x = 0.5 * (levels[i] + levels[i + 1])
+
+        if y is None:
+            y_min, y_max = ax.get_ylim()
+            y = y_min + (0.22 + 0.18 * (i % 2)) * (y_max - y_min)
+
+        ax.text(
+            x,
+            y,
+            label,
+            fontsize=fontsize,
+            color=color,
+            alpha=alpha,
+            fontweight=fontweight,
+            rotation=rotation,
+            ha="center",
+            va="center",
+            zorder=zorder,
+        )
+
+
 # =============================================================================
 # Continuous index fields (heatmaps)
 # =============================================================================
@@ -133,6 +198,8 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
             alpha=field_cfg.alpha,
             zorder=ZORDER["index_field"],
         )
+
+    _draw_index_field_labels(ax, field_cfg, levels, labels)
 
     if field_cfg.colorbar:
         cbar = chart.fig.colorbar(artist, ax=ax)

--- a/src/psychchart/plot/indexes.py
+++ b/src/psychchart/plot/indexes.py
@@ -21,6 +21,7 @@ from matplotlib.patches import PathPatch
 from matplotlib.colors import ListedColormap, BoundaryNorm, Normalize
 
 from psychchart.config.indexes import FieldRenderConfig, IsolineRenderConfig
+from psychchart.psychrometrics import Psychrometrics
 from psychchart.render.build_index_field import build_index_field
 from psychchart.plot.index_profiles import get_index_profile
 from psychchart.indexes.registry import INDEX_REGISTRY
@@ -73,12 +74,35 @@ def _get_index_layer(chart, index):
     return index_cls, layer
 
 
-def _resolve_field_label_position(position, fallback_label: str) -> tuple[float | None, float | None, str, float | None]:
+def _normalize_rh(rh: float | None) -> float | None:
+    """
+    Normalize relative humidity from fraction or percent to fraction.
+    """
+    if rh is None:
+        return None
+    return rh / 100.0 if rh > 1.0 else rh
+
+
+def _resolve_field_label_position(
+    position,
+    fallback_label: str,
+    pressure: float,
+) -> tuple[float | None, float | None, str, float | None]:
     """
     Normalize one manual label position.
+
+    Supported coordinate forms are:
+    - ``x``/``y``: raw chart coordinates, equivalent to T/W;
+    - ``t``/``w``: dry-bulb temperature and humidity ratio;
+    - ``t``/``rh``: dry-bulb temperature and relative humidity.
     """
     x = position.x if position.x is not None else position.t
     y = position.y if position.y is not None else position.w
+
+    if y is None and position.t is not None and position.rh is not None:
+        rh = _normalize_rh(position.rh)
+        y = Psychrometrics.humidity_ratio(position.t, rh, pressure)
+
     label = position.label or fallback_label
     return x, y, label, position.rotation
 
@@ -115,7 +139,7 @@ def _auto_field_label_position(ax: Axes, layer, lower: float, upper: float) -> t
     return float(np.nanmedian(x_values)), float(np.nanmedian(y_values))
 
 
-def _draw_index_field_labels(ax: Axes, layer, field_cfg, levels, labels) -> None:
+def _draw_index_field_labels(ax: Axes, layer, field_cfg, levels, labels, pressure: float) -> None:
     """
     Draw semantic class labels inside the psychrometric diagram.
     """
@@ -144,6 +168,7 @@ def _draw_index_field_labels(ax: Axes, layer, field_cfg, levels, labels) -> None
             x, y, label, manual_rotation = _resolve_field_label_position(
                 manual_positions[i],
                 label,
+                pressure,
             )
             if manual_rotation is not None:
                 rotation = manual_rotation
@@ -239,7 +264,7 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
             zorder=ZORDER["index_field"],
         )
 
-    _draw_index_field_labels(ax, layer, field_cfg, levels, labels)
+    _draw_index_field_labels(ax, layer, field_cfg, levels, labels, chart.cfg.pressure)
 
     if field_cfg.colorbar:
         cbar = chart.fig.colorbar(artist, ax=ax)

--- a/src/psychchart/plot/indexes.py
+++ b/src/psychchart/plot/indexes.py
@@ -83,7 +83,39 @@ def _resolve_field_label_position(position, fallback_label: str) -> tuple[float 
     return x, y, label, position.rotation
 
 
-def _draw_index_field_labels(ax: Axes, field_cfg, levels, labels) -> None:
+def _auto_field_label_position(ax: Axes, layer, lower: float, upper: float) -> tuple[float | None, float | None]:
+    """
+    Estimate an in-domain label position for one index-value interval.
+
+    The interval bounds are index values, not plot coordinates. Therefore the
+    position is computed from the centroid of the corresponding mask in the
+    psychrometric grid.
+    """
+    x_min, x_max = ax.get_xlim()
+    y_min, y_max = ax.get_ylim()
+
+    mask = (
+        np.isfinite(layer.Z)
+        & (layer.Z >= lower)
+        & (layer.Z < upper)
+        & np.isfinite(layer.X)
+        & np.isfinite(layer.Y)
+        & (layer.X >= x_min)
+        & (layer.X <= x_max)
+        & (layer.Y >= y_min)
+        & (layer.Y <= y_max)
+    )
+
+    if not np.any(mask):
+        return None, None
+
+    x_values = layer.X[mask]
+    y_values = layer.Y[mask]
+
+    return float(np.nanmedian(x_values)), float(np.nanmedian(y_values))
+
+
+def _draw_index_field_labels(ax: Axes, layer, field_cfg, levels, labels) -> None:
     """
     Draw semantic class labels inside the psychrometric diagram.
     """
@@ -116,12 +148,20 @@ def _draw_index_field_labels(ax: Axes, field_cfg, levels, labels) -> None:
             if manual_rotation is not None:
                 rotation = manual_rotation
 
-        if x is None:
-            x = 0.5 * (levels[i] + levels[i + 1])
+        if x is None or y is None:
+            auto_x, auto_y = _auto_field_label_position(
+                ax,
+                layer,
+                levels[i],
+                levels[i + 1],
+            )
+            if x is None:
+                x = auto_x
+            if y is None:
+                y = auto_y
 
-        if y is None:
-            y_min, y_max = ax.get_ylim()
-            y = y_min + (0.22 + 0.18 * (i % 2)) * (y_max - y_min)
+        if x is None or y is None:
+            continue
 
         ax.text(
             x,
@@ -199,7 +239,7 @@ def _draw_index_field(chart, ax: Axes, layer, cfg):
             zorder=ZORDER["index_field"],
         )
 
-    _draw_index_field_labels(ax, field_cfg, levels, labels)
+    _draw_index_field_labels(ax, layer, field_cfg, levels, labels)
 
     if field_cfg.colorbar:
         cbar = chart.fig.colorbar(artist, ax=ax)


### PR DESCRIPTION
Summary

This PR adds optional in-chart labels for semantic index classes rendered as field layers.

The feature is configured under render.field, because it controls how already-defined index labels are displayed. The semantic labels themselves remain at the index level.

Supported modes:
- automatic placement inside each indexed region
- manual placement using T x W coordinates
- manual placement using T x RH coordinates, with RH accepted as percentage or fraction

Example with automatic placement:

indexes:
  - index: ITU
    levels: [50, 63, 75, 79]
    colors: ["#1a9850", "#fee08b", "#fdae61"]
    labels: ["Conforto", "Alerta", "Estresse"]
    render:
      field:
        alpha: 0.70
        colorbar: false
        labels: true
        label_fontsize: 24
        label_rotation: -18

Manual placement with T x W:

render:
  field:
    labels: true
    label_positions:
      - label: "Conforto"
        t: 14
        w: 0.005
        rotation: -10

Manual placement with T x RH:

render:
  field:
    labels: true
    label_positions:
      - label: "Conforto"
        t: 14
        rh: 60
        rotation: -10
      - label: "Alerta"
        t: 23
        rh: 55
        rotation: -18
      - label: "Estresse"
        t: 34
        rh: 55
        rotation: -18

Rationale

This supports figures where the semantic classes are written directly inside the psychrometric field instead of being shown only through a colorbar, while still preserving colorbar-based rendering when desired.