### PR TITLE
Add tests and documentation for index field labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,55 @@ This allows:
 
 ---
 
+## Index field labels
+
+Continuous index fields can display their semantic class labels directly inside the psychrometric diagram. The index semantics remain defined at the index level through `levels`, `colors`, and `labels`; the nested `render.field.labels` option only controls whether those labels are drawn inside the field.
+
+```yaml
+indexes:
+  - index: ITU
+    label: "Temperature-Humidity Index (ITU)"
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert", "Stress"]
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+        labels: true
+        label_fontsize: 22
+        label_color: "#222222"
+        label_alpha: 0.85
+        label_fontweight: bold
+        label_rotation: -15
+```
+
+Manual positions may be declared either in chart coordinates (`t`/`w`) or in the more intuitive dry-bulb temperature and relative humidity form (`t`/`rh`). Relative humidity accepts both fractions and percentages.
+
+```yaml
+render:
+  field:
+    labels: true
+    label_positions:
+      - label: "Comfort"
+        t: 18
+        rh: 60
+      - label: "Alert"
+        t: 26
+        rh: 0.70
+      - label: "Stress"
+        t: 34
+        w: 0.020
+```
+
+A complete example is available at:
+
+```bash
+psychchart examples/itu_field_labels.yaml
+```
+
+---
+
 ## API usage
 
 ### Render chart (JSON)

--- a/examples/itu_field_labels.yaml
+++ b/examples/itu_field_labels.yaml
@@ -1,0 +1,62 @@
+chart:
+  t_min: 10
+  t_max: 45
+  pressure: 101325
+  y_min: 0.0
+  y_max: 0.035
+  xlabel: "Dry-bulb temperature (°C)"
+  ylabel: "Humidity ratio (kg/kg)"
+  title: "ITU semantic field labels"
+  output: "psychchart_itu_field_labels.png"
+  dpi: 200
+
+isolines:
+  relative_humidity:
+    enabled: true
+    values: [0.2, 0.4, 0.6, 0.8, 1.0]
+    color: "#8B1E3F"
+    linestyle: "-"
+    linewidth: 0.7
+    alpha: 0.45
+
+indexes:
+  - index: ITU
+    label: "Temperature-Humidity Index (ITU)"
+
+    # Index semantics: these values define the class intervals and their
+    # user-facing names. They are intentionally kept outside render.field.
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert", "Stress"]
+
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+
+        # Draw the semantic class labels directly inside the index field.
+        labels: true
+        label_fontsize: 22
+        label_color: "#222222"
+        label_alpha: 0.85
+        label_fontweight: bold
+        label_rotation: -15
+
+  - index: ITU
+    render:
+      isolines:
+        levels: [63, 75, 79]
+        style: ":"
+        color: black
+        linewidth: 1.4
+        alpha: 0.75
+        label: true
+        label_fontsize: 8
+        label_fmt: "ITU = {value:.0f}"
+
+points:
+  - label: "Example point"
+    t: 31
+    rh: 0.65
+    marker: "o"
+    color: black

--- a/src/psychchart/plot/indexes.py
+++ b/src/psychchart/plot/indexes.py
@@ -14,6 +14,8 @@ Non-responsibilities:
 """
 
 from __future__ import annotations
+import warnings
+
 import numpy as np
 from matplotlib.pyplot import get_cmap
 from matplotlib.axes import Axes
@@ -148,6 +150,14 @@ def _draw_index_field_labels(ax: Axes, layer, field_cfg, levels, labels, pressur
 
     n_intervals = len(levels) - 1
     if len(labels) != n_intervals:
+        warnings.warn(
+            "Index field labels were requested, but the number of labels "
+            f"({len(labels)}) does not match the number of level intervals "
+            f"({n_intervals}). Expected len(labels) == len(levels) - 1. "
+            "In-chart field labels will be skipped.",
+            UserWarning,
+            stacklevel=2,
+        )
         return
 
     fontsize = field_cfg.label_fontsize or 24.0

--- a/tests/test_index_field_labels.py
+++ b/tests/test_index_field_labels.py
@@ -229,3 +229,35 @@ indexes:
         assert "Stress" not in rendered
     finally:
         plt.close(chart.fig)
+
+
+def test_inconsistent_index_field_labels_emit_warning_and_are_skipped(tmp_path):
+    """Mismatched semantic labels should warn instead of failing silently."""
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 42
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+
+indexes:
+  - index: ITU
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert"]
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+        labels: true
+"""
+    with pytest.warns(UserWarning, match="number of labels"):
+        chart = _render_from_yaml(tmp_path, yaml)
+
+    try:
+        rendered = {text.get_text() for text in chart.ax.texts}
+        assert "Comfort" not in rendered
+        assert "Alert" not in rendered
+    finally:
+        plt.close(chart.fig)

--- a/tests/test_index_field_labels.py
+++ b/tests/test_index_field_labels.py
@@ -1,0 +1,231 @@
+"""Tests for semantic labels rendered inside index field layers."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pytest
+
+from psychchart import PsychChart, load_chart_config
+from psychchart.psychrometrics import Psychrometrics
+
+
+def _render_from_yaml(tmp_path, yaml: str) -> PsychChart:
+    """Load a temporary YAML configuration and render it in memory."""
+    cfg_path = tmp_path / "chart.yaml"
+    cfg_path.write_text(yaml, encoding="utf-8")
+
+    data = load_chart_config(cfg_path)
+    chart = PsychChart(**data)
+    chart.draw()
+    return chart
+
+
+def _text_by_label(chart: PsychChart, label: str):
+    """Return the first Matplotlib text artist matching a label."""
+    matches = [text for text in chart.ax.texts if text.get_text() == label]
+    assert matches, f"Label {label!r} was not rendered inside the chart"
+    return matches[0]
+
+
+def test_field_render_config_accepts_label_options(tmp_path):
+    """YAML label controls must be accepted by the typed configuration model."""
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 42
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+
+indexes:
+  - index: ITU
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert", "Stress"]
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+        labels: true
+        label_fontsize: 18
+        label_color: "#222222"
+        label_alpha: 0.90
+        label_fontweight: bold
+        label_rotation: -12
+"""
+    cfg_path = tmp_path / "chart.yaml"
+    cfg_path.write_text(yaml, encoding="utf-8")
+
+    data = load_chart_config(cfg_path)
+    field_cfg = data["indexes"][0].render.field
+
+    assert field_cfg.labels is True
+    assert field_cfg.label_fontsize == 18
+    assert field_cfg.label_color == "#222222"
+    assert field_cfg.label_alpha == 0.90
+    assert field_cfg.label_fontweight == "bold"
+    assert field_cfg.label_rotation == -12
+
+
+def test_automatic_index_field_labels_are_rendered(tmp_path):
+    """Semantic labels should appear inside the index field when enabled."""
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 42
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+
+indexes:
+  - index: ITU
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert", "Stress"]
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+        labels: true
+        label_fontsize: 14
+"""
+    chart = _render_from_yaml(tmp_path, yaml)
+
+    try:
+        rendered = {text.get_text() for text in chart.ax.texts}
+        assert {"Comfort", "Alert", "Stress"}.issubset(rendered)
+    finally:
+        plt.close(chart.fig)
+
+
+def test_manual_index_field_label_positions_in_t_w_coordinates(tmp_path):
+    """Manual T/W coordinates should be used directly as chart coordinates."""
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 42
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+
+indexes:
+  - index: ITU
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert", "Stress"]
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+        labels: true
+        label_fontsize: 14
+        label_positions:
+          - label: "Comfort"
+            t: 16.0
+            w: 0.006
+            rotation: -5
+          - label: "Alert"
+            t: 25.0
+            w: 0.012
+            rotation: -10
+          - label: "Stress"
+            t: 34.0
+            w: 0.020
+            rotation: -15
+"""
+    chart = _render_from_yaml(tmp_path, yaml)
+
+    try:
+        comfort = _text_by_label(chart, "Comfort")
+        alert = _text_by_label(chart, "Alert")
+        stress = _text_by_label(chart, "Stress")
+
+        assert comfort.get_position() == pytest.approx((16.0, 0.006))
+        assert alert.get_position() == pytest.approx((25.0, 0.012))
+        assert stress.get_position() == pytest.approx((34.0, 0.020))
+        assert comfort.get_rotation() == pytest.approx(355.0)  # Matplotlib normalizes -5 degrees.
+    finally:
+        plt.close(chart.fig)
+
+
+def test_manual_index_field_label_positions_in_t_rh_coordinates(tmp_path):
+    """Manual T/RH coordinates should be converted to humidity ratio."""
+    pressure = 101325
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 42
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+
+indexes:
+  - index: ITU
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert", "Stress"]
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+        labels: true
+        label_fontsize: 14
+        label_positions:
+          - label: "Comfort"
+            t: 18.0
+            rh: 60
+          - label: "Alert"
+            t: 26.0
+            rh: 0.70
+          - label: "Stress"
+            t: 34.0
+            rh: 80
+"""
+    chart = _render_from_yaml(tmp_path, yaml)
+
+    try:
+        comfort = _text_by_label(chart, "Comfort")
+        alert = _text_by_label(chart, "Alert")
+        stress = _text_by_label(chart, "Stress")
+
+        expected_comfort_y = Psychrometrics.humidity_ratio(18.0, 0.60, pressure)
+        expected_alert_y = Psychrometrics.humidity_ratio(26.0, 0.70, pressure)
+        expected_stress_y = Psychrometrics.humidity_ratio(34.0, 0.80, pressure)
+
+        assert comfort.get_position() == pytest.approx((18.0, expected_comfort_y))
+        assert alert.get_position() == pytest.approx((26.0, expected_alert_y))
+        assert stress.get_position() == pytest.approx((34.0, expected_stress_y))
+    finally:
+        plt.close(chart.fig)
+
+
+def test_index_field_labels_are_not_rendered_when_disabled(tmp_path):
+    """Semantic labels should remain hidden when render.field.labels is false."""
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 42
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+
+indexes:
+  - index: ITU
+    levels: [50, 63, 75, 79]
+    colors: ["#1a9850", "#fee08b", "#fdae61"]
+    labels: ["Comfort", "Alert", "Stress"]
+    render:
+      field:
+        alpha: 0.70
+        colorbar: false
+        labels: false
+"""
+    chart = _render_from_yaml(tmp_path, yaml)
+
+    try:
+        rendered = {text.get_text() for text in chart.ax.texts}
+        assert "Comfort" not in rendered
+        assert "Alert" not in rendered
+        assert "Stress" not in rendered
+    finally:
+        plt.close(chart.fig)


### PR DESCRIPTION
## Summary

This PR closes the index field labels feature with release-quality coverage and documentation.

It adds:

- dedicated tests for semantic labels rendered inside index field layers;
- coverage for automatic label placement;
- coverage for manual `T/W` positions;
- coverage for manual `T/RH` positions, including RH as percentage and fraction;
- coverage for disabled labels;
- a warning when `len(labels) != len(levels) - 1`, avoiding silent misconfiguration;
- a complete YAML example at `examples/itu_field_labels.yaml`;
- README documentation for `render.field.labels` and `label_positions`.

## Validation

The local execution environment could not resolve `github.com`, so I could not clone and run the test suite locally from the sandbox. The changes were prepared through the GitHub connector and should be validated by the repository CI.

Recommended commands for manual validation:

```bash
pytest
psychchart examples/itu_field_labels.yaml
psychchart examples/itu_full.yaml
psychchart examples/bovine_bioclimatic_final_azevedo.yaml
psychchart examples/thermal_trajectory_classified.yaml
```

## Notes

This PR preserves the existing architecture: index semantics remain defined through `levels`, `colors`, and `labels`; the nested `render.field.labels` option only controls whether those semantic labels are drawn inside the psychrometric field.