### PR TITLE
Stabilize operational overlays with declarative policy engine

### DIFF
--- a/docs/OPERATIONAL_OVERLAYS.md
+++ b/docs/OPERATIONAL_OVERLAYS.md
@@ -35,6 +35,11 @@ operational_overlays:
 The profile defines the policy. The overlay projects one representative state
 of that policy onto the psychrometric chart.
 
+Internally, the renderer resolves the validated `OperationalProfile` and uses
+the same deterministic decision engine exposed by `psychchart.operations.engine`.
+This keeps YAML validation, policy evaluation, colors, labels, legends and
+rendered regions tied to a single declarative source of truth.
+
 ## Built-in dairy profile
 
 psychChart includes a built-in profile named `dairy_cooling_default`.
@@ -53,6 +58,12 @@ operational_overlays:
 
 Define `operational_profiles` explicitly only when a custom management policy
 is needed.
+
+A minimal runnable example is available at:
+
+```bash
+psychchart examples/operational_overlay_minimal.yaml
+```
 
 ## Profiles
 
@@ -109,6 +120,9 @@ action_styles:
   O5: {label: "Emergência", facecolor: "#d73027"}
 ```
 
+These style definitions are also used by the overlay renderer for categorical
+filled regions, colorbars and legends.
+
 ## Modifiers
 
 Modifiers escalate or de-escalate the base action.
@@ -135,6 +149,17 @@ modifiers:
 
 This makes the policy dynamic: the same T x RH point can receive different
 actions depending on accumulated load and trend.
+
+For static overlays, `trend` is converted to a representative derivative:
+
+| trend | representative `dca_dt` |
+|---|---:|
+| falling | -0.002 |
+| steady | 0.000 |
+| rising | 0.002 |
+
+This allows the same declarative decision engine to be used both for static
+chart overlays and future time-series operational diagnostics.
 
 ## Rendering
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -30,6 +30,11 @@ psychchart examples/bovinos_racas.yaml
 psychchart examples/bovine_bioclimatic_final_azevedo.yaml
 psychchart examples/itu_field_labels.yaml
 
+Operational decision examples
+-----------------------------
+
+psychchart examples/operational_overlay_minimal.yaml
+
 Notes
 -----
 

--- a/examples/operational_overlay_minimal.yaml
+++ b/examples/operational_overlay_minimal.yaml
@@ -1,0 +1,49 @@
+chart:
+  t_min: 10
+  t_max: 42
+  y_min: 0.0
+  y_max: 0.034
+  pressure: 101325
+  xlabel: "Dry-bulb temperature (°C)"
+  ylabel: "Humidity ratio (kg/kg)"
+  title: "Operational cooling overlay — dairy default policy"
+  output: "operational_overlay_minimal.png"
+  dpi: 180
+
+isolines:
+  relative_humidity:
+    enabled: true
+    values: [0.2, 0.4, 0.6, 0.8, 1.0]
+    color: "#555555"
+    linestyle: "-"
+    linewidth: 0.6
+    alpha: 0.45
+
+indexes:
+  - index: ITU
+    label: ITU
+    render:
+      isolines:
+        levels: [72, 78, 84, 90]
+        color: black
+        linewidth: 1.1
+        style: ":"
+        alpha: 0.80
+        label: true
+        label_fontsize: 8
+        label_fmt: "ITU {value:.0f}"
+
+# Uses the built-in dairy_cooling_default operational profile.
+# The overlay projects the policy for one accumulated-load class and trend.
+operational_overlays:
+  - load_class: A2
+    trend: steady
+    alpha: 0.20
+    zorder: 0.55
+    n_t: 160
+    n_rh: 120
+    show_boundaries: true
+    boundary_alpha: 0.35
+    boundary_linewidth: 0.45
+    show_legend: true
+    label: "Cooling action"

--- a/src/psychchart/plot/operational_zones.py
+++ b/src/psychchart/plot/operational_zones.py
@@ -15,13 +15,16 @@ from matplotlib.axes import Axes
 from matplotlib.colors import BoundaryNorm, ListedColormap
 from matplotlib.patches import Patch
 
-from psychchart.config.operations import OperationalOverlayConfig
+from psychchart.config.operations import (
+    DEFAULT_DAIRY_OPERATIONAL_PROFILE_NAME,
+    OperationalOverlayConfig,
+)
 from psychchart.indexes.itu import ITU
-from psychchart.operations.management_engine import (
-    ACTIONS,
-    action_colors,
-    action_labels,
-    classify_management,
+from psychchart.operations.engine import action
+from psychchart.operations.enums import OperationalAction
+from psychchart.operations.profile import (
+    DEFAULT_DAIRY_COOLING_PROFILE,
+    OperationalProfile,
 )
 from psychchart.psychrometrics import Psychrometrics
 
@@ -93,35 +96,82 @@ def _trend_name(value: str) -> str:
     return str(value).lower()
 
 
-def _representative_cta(chart, cfg: OperationalOverlayConfig) -> float:
+def _trend_to_dca_dt(value: str) -> float:
     """
-    Resolve representative CTA from overlay load class.
+    Convert a static overlay trend name into a representative dCA/dt value.
 
-    The interactive overlay uses a static psychrometric field. Since a true CTA
-    is temporal, this value represents the selected accumulated-load class for
-    the whole field. It keeps the operational surface explicitly tied to load
-    class while avoiding hidden time integration inside the renderer.
+    Operational overlays are static psychrometric projections. The trend cannot
+    be inferred from a time series at this layer, so the configured trend is
+    represented by a small deterministic derivative that activates the profile
+    modifiers when appropriate.
     """
-    profile_name = getattr(cfg, "profile", "default")
-    load_class = getattr(cfg, "load_class", "A2")
+    trend = _trend_name(value)
+    if trend == "rising":
+        return 0.002
+    if trend == "falling":
+        return -0.002
+    return 0.0
+
+
+def _resolve_operational_profile(
+    chart,
+    cfg: OperationalOverlayConfig,
+) -> OperationalProfile:
+    """Resolve the runtime operational profile referenced by an overlay."""
+    profile_name = getattr(cfg, "profile", DEFAULT_DAIRY_OPERATIONAL_PROFILE_NAME)
     profiles = getattr(chart, "operational_profiles", {}) or {}
     profile_cfg = profiles.get(profile_name)
 
     if profile_cfg is not None:
-        try:
-            runtime = profile_cfg.to_runtime()
-            return float(runtime.get_load_class(load_class).representative_value())
-        except Exception:
-            pass
+        return profile_cfg.to_runtime()
 
-    fallback = {
-        "A0": 0.0,
-        "A1": 10.0,
-        "A2": 30.0,
-        "A3": 60.0,
-        "A4": 90.0,
-    }
-    return fallback.get(str(load_class), 30.0)
+    if profile_name == DEFAULT_DAIRY_OPERATIONAL_PROFILE_NAME:
+        return DEFAULT_DAIRY_COOLING_PROFILE
+
+    raise KeyError(f"Unknown operational profile: {profile_name!r}")
+
+
+def _representative_cta(profile: OperationalProfile, cfg: OperationalOverlayConfig) -> float:
+    """
+    Resolve representative CTA from the selected overlay load class.
+
+    The interactive overlay uses a static psychrometric field. Since true CTA is
+    temporal, this value represents the selected accumulated-load class for the
+    whole field. It keeps the operational surface explicitly tied to load class
+    without hiding time integration inside the renderer.
+    """
+    load_class = getattr(cfg, "load_class", "A2")
+    return float(profile.get_load_class(load_class).representative_value())
+
+
+def _classify_grid_with_profile(
+    profile: OperationalProfile,
+    T_grid: np.ndarray,
+    RH_grid: np.ndarray,
+    ITU_grid: np.ndarray,
+    *,
+    ca: float,
+    dca_dt: float,
+) -> np.ndarray:
+    """Evaluate the declarative operational engine over a grid."""
+    flat_actions = [
+        int(
+            action(
+                profile,
+                T=float(T),
+                RH=float(RH),
+                itu=float(itu),
+                ca=ca,
+                dca_dt=dca_dt,
+            )
+        )
+        for T, RH, itu in zip(
+            T_grid.ravel(),
+            RH_grid.ravel(),
+            ITU_grid.ravel(),
+        )
+    ]
+    return np.asarray(flat_actions, dtype=int).reshape(T_grid.shape)
 
 
 def _build_management_field(
@@ -132,6 +182,10 @@ def _build_management_field(
     n_t = int(getattr(cfg, "n_t", 220))
     n_rh = int(getattr(cfg, "n_rh", 180))
 
+    profile = _resolve_operational_profile(chart, cfg)
+    ca = _representative_cta(profile, cfg)
+    dca_dt = _trend_to_dca_dt(getattr(cfg, "trend", "steady"))
+
     t_values = np.linspace(chart.cfg.t_min, chart.cfg.t_max, n_t)
     rh_values = np.linspace(0.0, 1.0, n_rh)
     T_grid, RH_grid = np.meshgrid(t_values, rh_values)
@@ -140,13 +194,13 @@ def _build_management_field(
     W_grid = np.asarray(humidity_ratio_evaluator(T_grid, RH_grid), dtype=float)
     ITU_grid = np.asarray(_default_itu_evaluator(T_grid, RH_grid), dtype=float)
 
-    CTA_grid = np.full_like(ITU_grid, _representative_cta(chart, cfg), dtype=float)
-    action_grid = classify_management(
+    action_grid = _classify_grid_with_profile(
+        profile,
         T_grid,
         RH_grid,
         ITU_grid,
-        CTA_grid,
-        trend=_trend_name(getattr(cfg, "trend", "steady")),
+        ca=ca,
+        dca_dt=dca_dt,
     )
 
     mask = ~np.isfinite(W_grid)
@@ -157,31 +211,39 @@ def _build_management_field(
     if y_max is not None:
         mask |= W_grid > y_max
 
-    return T_grid, W_grid, np.ma.masked_array(action_grid, mask=mask)
+    return T_grid, W_grid, np.ma.masked_array(action_grid, mask=mask), profile
 
 
-def _build_action_colormap():
-    """Build categorical colormap and norm for management actions."""
-    colors = action_colors()
-    ordered_codes = [action.code for action in ACTIONS]
-    cmap = ListedColormap([colors[code] for code in ordered_codes])
-    levels = np.arange(-0.5, len(ordered_codes) + 0.5, 1.0)
+def _ordered_actions() -> list[OperationalAction]:
+    """Return operational actions in their semantic severity order."""
+    return list(OperationalAction)
+
+
+def _build_action_colormap(profile: OperationalProfile):
+    """Build categorical colormap and norm for profile-defined actions."""
+    ordered_actions = _ordered_actions()
+    cmap = ListedColormap(
+        [profile.action_styles[action].facecolor for action in ordered_actions]
+    )
+    levels = np.arange(-0.5, len(ordered_actions) + 0.5, 1.0)
     norm = BoundaryNorm(levels, cmap.N)
     return cmap, norm, levels
 
 
-def _legend_handles():
-    """Build proxy legend handles for management actions."""
-    labels = action_labels()
-    colors = action_colors()
-    return [
-        Patch(
-            facecolor=colors[action.code],
-            edgecolor="black",
-            label=labels[action.code],
+def _legend_handles(profile: OperationalProfile):
+    """Build proxy legend handles for profile-defined operational actions."""
+    handles = []
+    for action_code in _ordered_actions():
+        style = profile.action_styles[action_code]
+        handles.append(
+            Patch(
+                facecolor=style.facecolor,
+                edgecolor=style.edgecolor if style.edgecolor != "none" else "black",
+                hatch=style.hatch,
+                label=style.label,
+            )
         )
-        for action in ACTIONS
-    ]
+    return handles
 
 
 def draw_operational_zones(
@@ -190,8 +252,8 @@ def draw_operational_zones(
     cfg: OperationalOverlayConfig,
 ) -> None:
     """Draw one bovine thermal-management overlay."""
-    T_grid, W_grid, action_grid = _build_management_field(chart, cfg)
-    cmap, norm, levels = _build_action_colormap()
+    T_grid, W_grid, action_grid, profile = _build_management_field(chart, cfg)
+    cmap, norm, levels = _build_action_colormap(profile)
 
     artist = ax.contourf(
         T_grid,
@@ -210,7 +272,7 @@ def draw_operational_zones(
             T_grid,
             W_grid,
             action_grid,
-            levels=np.arange(0.5, len(ACTIONS), 1.0),
+            levels=np.arange(0.5, len(_ordered_actions()), 1.0),
             colors=cfg.boundary_color,
             linewidths=cfg.boundary_linewidth,
             alpha=cfg.boundary_alpha,
@@ -219,13 +281,15 @@ def draw_operational_zones(
 
     if cfg.show_colorbar:
         cbar = plt.colorbar(artist, ax=ax, pad=0.02)
-        cbar.set_ticks(np.arange(len(ACTIONS)))
-        cbar.set_ticklabels([action.label for action in ACTIONS])
+        cbar.set_ticks([int(action_code) for action_code in _ordered_actions()])
+        cbar.set_ticklabels(
+            [profile.action_styles[action_code].label for action_code in _ordered_actions()]
+        )
         cbar.set_label(cfg.colorbar_label)
 
     if cfg.show_legend:
         ax.legend(
-            handles=_legend_handles(),
+            handles=_legend_handles(profile),
             title=cfg.label or "Thermal-management action",
             loc="best",
         )

--- a/tests/test_bioclimatic_examples.py
+++ b/tests/test_bioclimatic_examples.py
@@ -23,6 +23,7 @@ VALIDATED_EXAMPLES = [
     "examples/bovinos_racas.yaml",
     "examples/bovine_bioclimatic_final_azevedo.yaml",
     "examples/itu_field_labels.yaml",
+    "examples/operational_overlay_minimal.yaml",
 ]
 
 

--- a/tests/test_operational_overlay.py
+++ b/tests/test_operational_overlay.py
@@ -1,6 +1,18 @@
 import textwrap
 
+import matplotlib.pyplot as plt
+import pytest
+from matplotlib.colors import to_rgba
+
 from psychchart import PsychChart, load_chart_config
+from psychchart.operations.engine import action
+from psychchart.operations.enums import OperationalAction
+from psychchart.operations.profile import DEFAULT_DAIRY_COOLING_PROFILE
+from psychchart.plot.operational_zones import (
+    _build_action_colormap,
+    _build_management_field,
+    _trend_to_dca_dt,
+)
 
 
 def _render_config(tmp_path, yaml_content: str):
@@ -14,6 +26,10 @@ def _render_config(tmp_path, yaml_content: str):
     assert ax is not None
     assert len(ax.collections) > 0
     return data, chart, ax
+
+
+def _close_chart(chart):
+    plt.close(chart.fig)
 
 
 def test_operational_overlay_smoke_with_explicit_profile(tmp_path):
@@ -83,11 +99,14 @@ def test_operational_overlay_smoke_with_explicit_profile(tmp_path):
         show_boundaries: true
     """
 
-    data, _, _ = _render_config(tmp_path, yaml_content)
+    data, chart, _ = _render_config(tmp_path, yaml_content)
 
-    assert "operational_profiles" in data
-    assert "operational_overlays" in data
-    assert data["operational_overlays"][0].load_class == "A2"
+    try:
+        assert "operational_profiles" in data
+        assert "operational_overlays" in data
+        assert data["operational_overlays"][0].load_class == "A2"
+    finally:
+        _close_chart(chart)
 
 
 def test_operational_overlay_uses_default_dairy_profile(tmp_path):
@@ -112,8 +131,96 @@ def test_operational_overlay_uses_default_dairy_profile(tmp_path):
         show_boundaries: true
     """
 
-    data, _, _ = _render_config(tmp_path, yaml_content)
+    data, chart, _ = _render_config(tmp_path, yaml_content)
 
-    assert "dairy_cooling_default" in data["operational_profiles"]
-    assert data["operational_overlays"][0].profile == "dairy_cooling_default"
-    assert data["operational_overlays"][0].load_class == "A2"
+    try:
+        assert "dairy_cooling_default" in data["operational_profiles"]
+        assert data["operational_overlays"][0].profile == "dairy_cooling_default"
+        assert data["operational_overlays"][0].load_class == "A2"
+    finally:
+        _close_chart(chart)
+
+
+def test_operational_overlay_colormap_uses_declarative_profile_styles():
+    """Overlay colors must come from the runtime profile, not a legacy classifier."""
+    cmap, _, _ = _build_action_colormap(DEFAULT_DAIRY_COOLING_PROFILE)
+
+    assert cmap.N == len(OperationalAction)
+
+    for action_code in OperationalAction:
+        expected = to_rgba(DEFAULT_DAIRY_COOLING_PROFILE.action_styles[action_code].facecolor)
+        assert cmap(int(action_code)) == pytest.approx(expected)
+
+
+def test_operational_overlay_trend_maps_to_profile_modifier_derivative():
+    """Static overlay trends should activate declarative engine modifiers."""
+    profile = DEFAULT_DAIRY_COOLING_PROFILE
+
+    steady = action(
+        profile,
+        T=28.0,
+        RH=0.65,
+        itu=76.0,
+        ca=0.0125,
+        dca_dt=_trend_to_dca_dt("steady"),
+    )
+    rising = action(
+        profile,
+        T=28.0,
+        RH=0.65,
+        itu=76.0,
+        ca=0.0125,
+        dca_dt=_trend_to_dca_dt("rising"),
+    )
+    falling = action(
+        profile,
+        T=28.0,
+        RH=0.65,
+        itu=76.0,
+        ca=0.0025,
+        dca_dt=_trend_to_dca_dt("falling"),
+    )
+
+    assert rising > steady
+    assert falling <= steady
+
+
+def test_operational_overlay_field_uses_configured_load_class_and_trend(tmp_path):
+    """Generated fields should reflect the configured load class and trend."""
+    yaml_content = """
+    profile: default_si
+
+    chart:
+      t_min: 20
+      t_max: 34
+      y_min: 0.0
+      y_max: 0.032
+      pressure: 101325
+      output: operational_overlay_field.png
+
+    operational_overlays:
+      - load_class: A0
+        trend: rising
+        alpha: 0.15
+        n_t: 18
+        n_rh: 16
+        show_boundaries: true
+    """
+
+    data = load_chart_config(tmp_path / "missing.yaml") if False else None
+
+    cfg_path = tmp_path / "operational_overlay_field.yaml"
+    cfg_path.write_text(textwrap.dedent(yaml_content), encoding="utf-8")
+    payload = load_chart_config(cfg_path)
+    chart = PsychChart(**payload)
+    overlay_cfg = payload["operational_overlays"][0]
+
+    T_grid, W_grid, action_grid, profile = _build_management_field(chart, overlay_cfg)
+
+    assert profile.name == "dairy_cooling_default"
+    assert T_grid.shape == (16, 18)
+    assert W_grid.shape == (16, 18)
+    assert action_grid.shape == (16, 18)
+    assert action_grid.compressed().size > 0
+    assert action_grid.max() <= int(OperationalAction.EMERGENCY)
+    assert action_grid.min() >= int(OperationalAction.MONITOR)

--- a/tests/test_operational_overlay.py
+++ b/tests/test_operational_overlay.py
@@ -207,8 +207,6 @@ def test_operational_overlay_field_uses_configured_load_class_and_trend(tmp_path
         show_boundaries: true
     """
 
-    data = load_chart_config(tmp_path / "missing.yaml") if False else None
-
     cfg_path = tmp_path / "operational_overlay_field.yaml"
     cfg_path.write_text(textwrap.dedent(yaml_content), encoding="utf-8")
     payload = load_chart_config(cfg_path)


### PR DESCRIPTION
## Summary

This PR stabilizes operational overlays by aligning the renderer with the declarative operational policy engine.

The main change is that `plot/operational_zones.py` no longer uses the legacy numeric management classifier as its source of truth. Instead, the renderer now resolves the validated `OperationalProfile` and evaluates actions through `psychchart.operations.engine.action`.

This keeps the operational layer consistent with the project architecture:

- YAML validation defines the profile;
- `OperationalProfile` defines thresholds, actions, labels and styles;
- `operations.engine` evaluates the policy;
- the renderer only projects the resulting action field onto the psychrometric chart.

## Changes

- Render operational overlays from the declarative `OperationalProfile` runtime model.
- Use profile-defined `action_styles` for categorical colors, colorbars and legends.
- Convert static overlay `trend` values into representative `dca_dt` values so the same decision engine can be used for static overlays and future time-series diagnostics.
- Add `examples/operational_overlay_minimal.yaml` as a small runnable example.
- Include the minimal operational overlay example in the validated YAML smoke-test set.
- Expand operational overlay tests to cover:
  - default dairy profile injection;
  - explicit profile rendering;
  - profile-driven colormap generation;
  - trend-to-modifier behavior;
  - generated field shape and action bounds.
- Update `docs/OPERATIONAL_OVERLAYS.md` and `examples/README.txt`.

## Validation

Please validate with:

```bash
pytest
psychchart examples/operational_overlay_minimal.yaml
psychchart examples/thermal_trajectory_classified.yaml
```

## Notes

This PR intentionally avoids changing the public YAML surface beyond adding a minimal example. The focus is internal consistency: operational overlays now use the same declarative decision engine as the rest of the operational policy layer.