### PR TITLE
Bump package version to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "psychchart"
-version = "1.0.0"
+version = "1.0.1"
 description = "Psychrometric chart generator with YAML-driven configuration"
 readme = "README.md"
 license = { text = "LGPL-3.0" }


### PR DESCRIPTION
## Summary

This PR aligns the package metadata with the existing `v1.0.1` release tag and changelog.

## Change

- Updates `pyproject.toml` from `version = "1.0.0"` to `version = "1.0.1"`.

## Scope

Build metadata only. No runtime code changes.

## Suggested validation

```bash
python -m pip install -e ".[dev]"
python -c "import importlib.metadata as m; print(m.version('psychchart'))"
pytest
```
