### PR TITLE
Add API point readout endpoint

### DIFF
--- a/src/psychchart/api/fastapi_app.py
+++ b/src/psychchart/api/fastapi_app.py
@@ -11,7 +11,12 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from psychchart.api.workspace import ProjectRecord, WorkspaceStore
-from psychchart.app.services import close_figure, figure_to_bytes, render_figure_from_yaml
+from psychchart.app.services import (
+    close_figure,
+    compute_point_readout,
+    figure_to_bytes,
+    render_figure_from_yaml,
+)
 
 ImageFormat = Literal["png", "svg", "pdf"]
 
@@ -39,6 +44,22 @@ class RenderBase64Response(BaseModel):
     format: ImageFormat
     media_type: str
     data_base64: str
+
+
+class ReadoutRequest(BaseModel):
+    T: float = Field(..., description="Dry-bulb temperature in Celsius.")
+    RH_pct: float = Field(..., ge=0, le=100, description="Relative humidity in percent.")
+    pressure: float = Field(default=101325.0, gt=0, description="Air pressure in Pa.")
+
+
+class ReadoutResponse(BaseModel):
+    T: float
+    RH_pct: float
+    RH: float
+    W: float
+    h: float
+    Tdp: float
+    ITU: float
 
 
 class ProjectCreateRequest(BaseModel):
@@ -81,6 +102,15 @@ app.add_middleware(
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.post("/readout", response_model=ReadoutResponse)
+def readout(req: ReadoutRequest) -> ReadoutResponse:
+    try:
+        result = compute_point_readout(T=req.T, RH_pct=req.RH_pct, pressure=req.pressure)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ReadoutResponse(**result.as_dict())
 
 
 @app.post("/render", response_model=RenderBase64Response)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,33 @@ def test_health():
     assert response.json()["status"] == "ok"
 
 
+def test_readout():
+    response = client.post(
+        "/readout",
+        json={"T": 31.0, "RH_pct": 65.0, "pressure": 101325.0},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["T"] == 31.0
+    assert data["RH_pct"] == 65.0
+    assert data["RH"] == 0.65
+    assert data["W"] > 0.0
+    assert data["h"] > 0.0
+    assert "Tdp" in data
+    assert "ITU" in data
+
+
+def test_readout_rejects_invalid_relative_humidity():
+    response = client.post(
+        "/readout",
+        json={"T": 31.0, "RH_pct": 120.0, "pressure": 101325.0},
+    )
+
+    assert response.status_code == 422
+
+
 def test_render_png():
     yaml = """
 chart:


### PR DESCRIPTION
## Summary

This PR extracts the first small, safe piece from the `marsh-ui` branch: the FastAPI point readout endpoint required by the interactive frontend.

It adds:

- `POST /readout` endpoint;
- `ReadoutRequest` and `ReadoutResponse` API models;
- integration with the existing `compute_point_readout()` application service;
- tests for a valid readout response;
- validation coverage for invalid relative humidity.

## Why

The `marsh-ui` frontend calls `/readout` to compute point-level diagnostics for interactive cursor/readout workflows, including:

- dry-bulb temperature;
- relative humidity;
- humidity ratio;
- enthalpy;
- dew point;
- ITU.

This keeps the frontend from reimplementing scientific calculations in JavaScript and preserves the Python package as the source of truth.

## Scope

Backend API only. No frontend changes in this PR.

## Suggested validation

```bash
pytest
uvicorn psychchart.api.fastapi_app:app --reload
```

Manual API check:

```bash
curl -X POST http://127.0.0.1:8000/readout \
  -H 'Content-Type: application/json' \
  -d '{"T": 31.0, "RH_pct": 65.0, "pressure": 101325.0}'
```
