### PR TITLE
Add interactive workspace base layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,32 +3,111 @@ import ChartPreview from './app/preview/ChartPreview'
 import YamlEditor from './app/editor/YamlEditor'
 import Presets from './app/editor/Presets'
 import WorkspacePanel from './app/components/WorkspacePanel'
+import { exportChartFile } from './app/api/client'
+import { appendReadoutPointToYaml } from './app/utils/yamlDomain'
 
 export default function App() {
-  const [yaml, setYaml] = useState('chart:\n  t_min: 10\n  t_max: 40')
+  const [yaml, setYaml] = useState('chart:\n  t_min: 10\n  t_max: 40\nindexes:\n  - index: ITU')
+  const [showYaml, setShowYaml] = useState(true)
+  const [activePanel, setActivePanel] = useState('layers')
+  const [readout, setReadout] = useState(null)
+
+  const handleExport = async (format) => {
+    const blob = await exportChartFile({ yaml, format, dpi: 300 })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `psychchart.${format}`
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const handleAddPoint = () => {
+    if (!readout) return
+    setYaml(appendReadoutPointToYaml(yaml, readout))
+  }
 
   return (
-    <div style={{ display: 'flex', height: '100vh', fontFamily: 'Arial' }}>
+    <div className="workstation">
+      <header className="topbar">
+        <div>
+          <div className="product-name">psychChart</div>
+          <div className="product-caption">Interactive psychrometric analysis workspace</div>
+        </div>
+        <div className="topbar-actions">
+          <button className="btn" onClick={() => setShowYaml(!showYaml)}>
+            {showYaml ? 'Hide YAML' : 'Show YAML'}
+          </button>
+          <button className="btn" onClick={() => handleExport('png')}>Export PNG</button>
+          <button className="btn" onClick={() => handleExport('svg')}>Export SVG</button>
+        </div>
+      </header>
 
-      <div style={{ width: 260, padding: 12, borderRight: '1px solid #ccc', background: '#fafafa' }}>
-        <h3>psychChart</h3>
-        <Presets setYaml={setYaml} />
-      </div>
+      <aside className="left-rail panel">
+        <div className="panel-header compact">
+          <div className="panel-title">Workspace</div>
+          <div className="subtitle">Projects, presets and data sources.</div>
+        </div>
+        <div className="section">
+          <Presets setYaml={setYaml} />
+        </div>
+        <div className="section muted-card">
+          <div className="section-title">Data import</div>
+          <p className="small-text">CSV/Parquet import will appear here. The YAML remains the reproducible source of truth.</p>
+          <button className="btn btn-full" disabled>Upload data</button>
+        </div>
+      </aside>
 
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+      <main className="chart-stage">
+        <ChartPreview yaml={yaml} onReadout={setReadout} />
+        {showYaml && (
+          <div className="panel editor-drawer">
+            <div className="toolbar">
+              <div className="toolbar-title">YAML / JSON configuration</div>
+              <div className="toolbar-note">Reproducible chart definition</div>
+            </div>
+            <YamlEditor yaml={yaml} setYaml={setYaml} />
+          </div>
+        )}
+      </main>
 
-        <div style={{ flex: 2, padding: 10 }}>
-          <ChartPreview yaml={yaml} />
+      <aside className="right-rail panel">
+        <div className="panel-tabs">
+          <button className={activePanel === 'layers' ? 'tab active' : 'tab'} onClick={() => setActivePanel('layers')}>Layers</button>
+          <button className={activePanel === 'readout' ? 'tab active' : 'tab'} onClick={() => setActivePanel('readout')}>Readout</button>
+          <button className={activePanel === 'projects' ? 'tab active' : 'tab'} onClick={() => setActivePanel('projects')}>Projects</button>
         </div>
 
-        <div style={{ flex: 1, padding: 10 }}>
-          <YamlEditor yaml={yaml} setYaml={setYaml} />
-        </div>
+        {activePanel === 'layers' && (
+          <div className="section">
+            <div className="section-title">Chart layers</div>
+            <label className="check-row"><input type="checkbox" defaultChecked /> Saturation curve</label>
+            <label className="check-row"><input type="checkbox" defaultChecked /> Relative humidity</label>
+            <label className="check-row"><input type="checkbox" defaultChecked /> Thermal indexes</label>
+            <label className="check-row"><input type="checkbox" /> Operational zones</label>
+            <div className="info-box">Use this panel to control isolines, overlays and index fields.</div>
+          </div>
+        )}
 
-      </div>
+        {activePanel === 'readout' && (
+          <div className="section">
+            <div className="section-title">Point readout</div>
+            <div className="metric-grid">
+              <div className="metric-card"><span>T</span><strong>{readout?.T?.toFixed(1) ?? '--'} °C</strong></div>
+              <div className="metric-card"><span>RH</span><strong>{readout?.RH_pct?.toFixed(0) ?? '--'} %</strong></div>
+              <div className="metric-card"><span>ITU</span><strong>{readout?.ITU?.toFixed(1) ?? '--'}</strong></div>
+              <div className="metric-card"><span>W</span><strong>{readout?.W?.toExponential(2) ?? '--'}</strong></div>
+              <div className="metric-card"><span>Enthalpy</span><strong>{readout?.h?.toFixed(1) ?? '--'}</strong></div>
+              <div className="metric-card"><span>Dew point</span><strong>{readout?.Tdp?.toFixed(1) ?? '--'} °C</strong></div>
+            </div>
+            <button className="btn btn-primary btn-full readout-action" disabled={!readout} onClick={handleAddPoint}>Add point to chart</button>
+          </div>
+        )}
 
-      <WorkspacePanel yaml={yaml} onLoad={setYaml} />
-
+        {activePanel === 'projects' && (
+          <WorkspacePanel yaml={yaml} onLoad={setYaml} />
+        )}
+      </aside>
     </div>
   )
 }

--- a/frontend/src/app/api/client.js
+++ b/frontend/src/app/api/client.js
@@ -42,6 +42,28 @@ export async function renderChart({ yaml, format = 'png', dpi = 180, apiBaseUrl 
   );
 }
 
+export async function exportChartFile({ yaml, format = 'png', dpi = 300, apiBaseUrl = DEFAULT_API_BASE_URL }) {
+  const response = await fetch(`${apiBaseUrl}/render/file`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ yaml, format, dpi }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response));
+  }
+
+  return response.blob();
+}
+
+export async function computeReadout({ T, RH_pct, pressure = 101325 }) {
+  return requestJson('/readout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ T, RH_pct, pressure }),
+  });
+}
+
 export async function listProjects() {
   return requestJson('/projects');
 }

--- a/frontend/src/app/preview/ChartPreview.jsx
+++ b/frontend/src/app/preview/ChartPreview.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
-import { renderChart, buildDataUrl } from '../api/client'
+import { renderChart, buildDataUrl, computeReadout } from '../api/client'
+import { getChartDomain } from '../utils/yamlDomain'
 
-export default function ChartPreview({ yaml }) {
+export default function ChartPreview({ yaml, onReadout }) {
   const [imageSrc, setImageSrc] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [marker, setMarker] = useState(null)
 
   const handleRender = async () => {
     setLoading(true)
@@ -19,24 +21,43 @@ export default function ChartPreview({ yaml }) {
     }
   }
 
+  const handleSelect = async (event) => {
+    if (!imageSrc) return
+    const rect = event.currentTarget.getBoundingClientRect()
+    const xRatio = Math.min(Math.max((event.clientX - rect.left) / rect.width, 0), 1)
+    const yRatio = Math.min(Math.max((event.clientY - rect.top) / rect.height, 0), 1)
+    const domain = getChartDomain(yaml)
+    const T = domain.tMin + xRatio * (domain.tMax - domain.tMin)
+    const RH_pct = domain.rhMax - yRatio * (domain.rhMax - domain.rhMin)
+    setMarker({ x: xRatio * 100, y: yRatio * 100 })
+    try {
+      const readout = await computeReadout({ T, RH_pct, pressure: domain.pressure })
+      onReadout?.(readout)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
   return (
     <div className="panel preview-card">
       <div className="toolbar">
-        <div className="toolbar-title">Preview</div>
+        <div>
+          <div className="toolbar-title">Interactive psychrometric chart</div>
+          <div className="toolbar-note">Render and select a region to inspect T/RH/ITU.</div>
+        </div>
         <button className="btn btn-primary" onClick={handleRender} disabled={loading}>
           {loading ? 'Rendering…' : 'Render'}
         </button>
       </div>
-
       {error && <div className="error-box">{error}</div>}
-
-      <div className="preview-body">
+      <div className="preview-body interactive-preview">
         {imageSrc ? (
-          <img src={imageSrc} className="preview-image" />
-        ) : (
-          <div className="empty-state">
-            Click "Render" to generate a chart preview.
+          <div className="image-click-layer" onClick={handleSelect}>
+            <img src={imageSrc} className="preview-image" />
+            {marker && <div className="click-marker" style={{ left: `${marker.x}%`, top: `${marker.y}%` }} />}
           </div>
+        ) : (
+          <div className="empty-state">Render the chart, then select a point to compute a psychrometric readout.</div>
         )}
       </div>
     </div>

--- a/frontend/src/app/utils/yamlDomain.js
+++ b/frontend/src/app/utils/yamlDomain.js
@@ -1,0 +1,33 @@
+export function readNumberFromYaml(yaml, key, fallback) {
+  const pattern = new RegExp(`\\b${key}\\s*:\\s*(-?\\d+(?:\\.\\d+)?)`)
+  const match = yaml.match(pattern)
+  return match ? Number(match[1]) : fallback
+}
+
+export function getChartDomain(yaml) {
+  return {
+    tMin: readNumberFromYaml(yaml, 't_min', 10),
+    tMax: readNumberFromYaml(yaml, 't_max', 40),
+    rhMin: 0,
+    rhMax: 100,
+    pressure: readNumberFromYaml(yaml, 'pressure', 101325),
+  }
+}
+
+export function appendReadoutPointToYaml(yaml, readout) {
+  const point = [
+    '  - t: ' + readout.T.toFixed(2),
+    '    rh: ' + readout.RH.toFixed(4),
+    '    label: "Clicked: T=' + readout.T.toFixed(1) + ' °C | RH=' + readout.RH_pct.toFixed(0) + '% | ITU=' + readout.ITU.toFixed(1) + '"',
+    '    marker: corner_cross',
+    '    color: "#111827"',
+    '    size: 360',
+    '    show_label: true',
+  ].join('\n')
+
+  if (/^points:\s*$/m.test(yaml)) {
+    return yaml.trimEnd() + '\n' + point + '\n'
+  }
+
+  return yaml.trimEnd() + '\n\npoints:\n' + point + '\n'
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,34 +1,73 @@
 :root {
-  --bg: #f4f7fb;
+  --bg: #eef3f8;
   --panel: #ffffff;
   --panel-soft: #f8fafc;
-  --border: #dce3ec;
-  --text: #102033;
-  --muted: #667085;
-  --primary: #2563eb;
-  --primary-dark: #1d4ed8;
+  --border: #d8e1ec;
+  --text: #111827;
+  --muted: #64748b;
+  --primary: #3156e7;
+  --primary-dark: #2445c7;
   --danger: #dc2626;
   --success: #15803d;
-  --shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  --shadow: 0 18px 44px rgba(15, 23, 42, 0.10);
 }
 
 * { box-sizing: border-box; }
 
+html, body, #root { height: 100%; }
+
 body {
   margin: 0;
-  background: var(--bg);
+  background: radial-gradient(circle at top left, #f8fbff 0, var(--bg) 44%, #e8eef7 100%);
   color: var(--text);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  overflow: hidden;
 }
 
 button, input, textarea { font: inherit; }
+button { appearance: none; }
 
-.app-shell {
+.workstation {
   display: grid;
-  grid-template-columns: 300px minmax(420px, 1fr) 380px;
+  grid-template-columns: 300px minmax(620px, 1fr) 360px;
+  grid-template-rows: 72px minmax(0, 1fr);
+  grid-template-areas:
+    'topbar topbar topbar'
+    'left main right';
+  gap: 14px;
   height: 100vh;
-  gap: 16px;
-  padding: 16px;
+  padding: 14px;
+}
+
+.topbar {
+  grid-area: topbar;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 18px;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+}
+
+.product-name {
+  font-size: 24px;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+}
+
+.product-caption {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .panel {
@@ -39,138 +78,135 @@ button, input, textarea { font: inherit; }
   overflow: hidden;
 }
 
-.sidebar, .workspace {
+.left-rail {
+  grid-area: left;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  min-width: 0;
+}
+
+.right-rail {
+  grid-area: right;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.chart-stage {
+  grid-area: main;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) 240px;
+  gap: 14px;
 }
 
 .panel-header {
-  padding: 18px 18px 12px;
+  padding: 18px;
   border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
 }
 
-.brand {
-  font-size: 22px;
-  font-weight: 800;
-  letter-spacing: -0.03em;
-}
+.panel-header.compact { padding: 16px 18px; }
+.panel-title { font-size: 17px; font-weight: 850; }
+.subtitle { margin-top: 5px; color: var(--muted); font-size: 13px; line-height: 1.4; }
 
-.subtitle {
-  margin-top: 6px;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.4;
-}
-
-.section {
-  padding: 16px 18px;
-}
-
+.section { padding: 18px; }
+.section + .section { border-top: 1px solid var(--border); }
 .section-title {
-  margin: 0 0 10px;
-  font-size: 13px;
-  font-weight: 800;
-  color: #344054;
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 900;
+  color: #334155;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
 }
 
-.main-area {
-  display: grid;
-  grid-template-rows: minmax(360px, 2fr) minmax(220px, 1fr);
-  gap: 16px;
-  min-width: 0;
-}
-
-.preview-card, .editor-card {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
+.small-text { color: var(--muted); font-size: 13px; line-height: 1.5; margin: 0 0 12px; }
+.muted-card { background: #fbfdff; }
 
 .toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 12px 14px;
+  min-height: 58px;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--border);
-  background: var(--panel-soft);
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
 }
 
-.toolbar-title {
-  font-weight: 800;
-}
+.toolbar-title { font-size: 15px; font-weight: 850; }
+.toolbar-note { margin-top: 2px; color: var(--muted); font-size: 12px; }
 
 .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   border: 1px solid var(--border);
   background: #fff;
   color: var(--text);
-  border-radius: 10px;
-  padding: 8px 12px;
+  border-radius: 12px;
+  padding: 9px 13px;
+  min-height: 38px;
   cursor: pointer;
-  transition: 0.15s ease;
+  transition: 0.16s ease;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
-.btn:hover { border-color: #b9c4d3; transform: translateY(-1px); }
-.btn:disabled { opacity: 0.65; cursor: not-allowed; transform: none; }
-
-.btn-primary {
-  background: var(--primary);
-  color: #fff;
-  border-color: var(--primary);
-}
-
+.btn:hover { border-color: #b8c4d4; transform: translateY(-1px); box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08); }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; box-shadow: none; }
+.btn-primary { background: var(--primary); color: #fff; border-color: var(--primary); }
 .btn-primary:hover { background: var(--primary-dark); border-color: var(--primary-dark); }
 .btn-danger { color: var(--danger); }
-.btn-small { padding: 6px 9px; font-size: 12px; }
+.btn-small { min-height: 30px; padding: 6px 9px; border-radius: 9px; font-size: 12px; }
+.btn-full { width: 100%; }
 
 .input {
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 9px 10px;
+  border-radius: 12px;
+  padding: 10px 12px;
   background: #fff;
+  outline: none;
 }
+.input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(49, 86, 231, 0.12); }
 
-.preset-grid {
-  display: grid;
-  gap: 8px;
-}
-
+.preset-grid { display: grid; gap: 10px; }
 .preset-button {
   width: 100%;
   text-align: left;
-  padding: 12px;
-  border-radius: 12px;
+  padding: 13px 14px;
+  border-radius: 14px;
   border: 1px solid var(--border);
-  background: #fff;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
   cursor: pointer;
+  font-weight: 700;
 }
-
 .preset-button:hover { border-color: var(--primary); background: #eff6ff; }
 
-.preview-body {
-  flex: 1;
+.preview-card, .editor-drawer {
+  display: flex;
+  flex-direction: column;
   min-height: 0;
-  overflow: auto;
-  background: #fff;
 }
-
-.preview-image {
-  width: 100%;
-  display: block;
+.preview-body { flex: 1; min-height: 0; overflow: auto; background: #fff; }
+.interactive-preview { cursor: crosshair; }
+.image-click-layer { position: relative; display: block; width: 100%; min-height: 100%; }
+.preview-image { width: 100%; display: block; user-select: none; }
+.click-marker {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  margin-left: -8px;
+  margin-top: -8px;
+  border: 3px solid #111827;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 0 0 4px rgba(49, 86, 231, 0.20);
+  pointer-events: none;
 }
-
-.empty-state {
-  height: 100%;
-  display: grid;
-  place-items: center;
-  padding: 24px;
-  color: var(--muted);
-  text-align: center;
-}
+.empty-state { height: 100%; display: grid; place-items: center; padding: 28px; color: var(--muted); text-align: center; }
 
 .error-box {
   margin: 12px;
@@ -180,16 +216,17 @@ button, input, textarea { font: inherit; }
   color: #991b1b;
   background: #fef2f2;
 }
-
-.success-box {
-  margin-top: 10px;
-  padding: 10px;
-  border-radius: 10px;
-  border: 1px solid #bbf7d0;
-  color: var(--success);
-  background: #f0fdf4;
+.info-box {
+  margin-top: 16px;
+  padding: 12px;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  color: #1e3a8a;
+  background: #eff6ff;
   font-size: 13px;
+  line-height: 1.45;
 }
+.success-box { margin-top: 10px; padding: 10px; border-radius: 10px; border: 1px solid #bbf7d0; color: var(--success); background: #f0fdf4; font-size: 13px; }
 
 .yaml-editor {
   flex: 1;
@@ -206,25 +243,36 @@ button, input, textarea { font: inherit; }
   color: #e5e7eb;
 }
 
-.project-list {
-  flex: 1;
-  overflow: auto;
-  padding: 10px 18px 18px;
+.panel-tabs { display: grid; grid-template-columns: repeat(3, 1fr); padding: 10px; gap: 6px; border-bottom: 1px solid var(--border); background: #f8fafc; }
+.tab {
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: 10px;
+  padding: 9px 8px;
+  cursor: pointer;
+  color: var(--muted);
+  font-weight: 750;
 }
+.tab.active { color: var(--primary); background: #fff; border-color: var(--border); box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06); }
 
-.project-card {
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 12px;
-  margin-bottom: 10px;
-  background: #fff;
-}
+.check-row { display: flex; align-items: center; gap: 9px; padding: 9px 0; color: #334155; }
+.metric-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.metric-card { border: 1px solid var(--border); border-radius: 14px; padding: 12px; background: #fff; }
+.metric-card span { display: block; color: var(--muted); font-size: 12px; font-weight: 750; margin-bottom: 5px; }
+.metric-card strong { font-size: 18px; letter-spacing: -0.03em; }
 
-.project-name { font-weight: 800; margin-bottom: 4px; }
+.project-list { flex: 1; overflow: auto; padding: 10px 18px 18px; }
+.project-card { border: 1px solid var(--border); border-radius: 14px; padding: 12px; margin-bottom: 10px; background: #fff; }
+.project-name { font-weight: 850; margin-bottom: 4px; }
 .project-meta { color: var(--muted); font-size: 12px; margin-bottom: 10px; }
 .project-actions { display: flex; gap: 8px; }
 
-@media (max-width: 1180px) {
-  .app-shell { grid-template-columns: 260px 1fr; }
-  .workspace { display: none; }
+@media (max-width: 1280px) {
+  .workstation { grid-template-columns: 260px minmax(520px, 1fr) 320px; }
+}
+
+@media (max-width: 980px) {
+  body { overflow: auto; }
+  .workstation { height: auto; min-height: 100vh; grid-template-columns: 1fr; grid-template-rows: auto; grid-template-areas: 'topbar' 'main' 'right' 'left'; }
+  .chart-stage { grid-template-rows: 520px 260px; }
 }


### PR DESCRIPTION
## Summary

This PR brings the validated base frontend layout from the `marsh-ui` branch into `main`.

It adds the interactive workspace structure, including:

- main workstation layout;
- chart preview with interactive point selection;
- YAML editor drawer;
- layers/readout/projects side panels;
- export helpers for PNG/SVG;
- frontend `/readout` integration;
- YAML utility for appending clicked readout points to the YAML configuration;
- refreshed workspace styling.

## Scope

Frontend only. No backend changes are included in this PR.

The backend `/readout` endpoint was already added in PR #16, so this PR only wires the UI to the existing API contract.

## Changed files

- `frontend/src/App.jsx`
- `frontend/src/app/api/client.js`
- `frontend/src/app/preview/ChartPreview.jsx`
- `frontend/src/app/utils/yamlDomain.js`
- `frontend/src/styles.css`

## Validation already performed locally

The UI was tested manually with:

```bash
uvicorn psychchart.api.fastapi_app:app --reload
cd frontend
npm install
VITE_PSYCHCHART_API_URL=http://127.0.0.1:8000 npm run dev
```

The frontend opened, rendered charts and the API URL configuration resolved the previous `/api` 404 issue.

## Suggested validation

```bash
pytest
cd frontend
npm install
npm run build
VITE_PSYCHCHART_API_URL=http://127.0.0.1:8000 npm run dev
```
