### PR TITLE
Add labels for index-derived zones

### DIFF
--- a/examples/index_zone_itu_labeled.yaml
+++ b/examples/index_zone_itu_labeled.yaml
@@ -1,0 +1,56 @@
+chart:
+  t_min: 10
+  t_max: 45
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+  xlabel: "Dry-bulb temperature (°C)"
+  ylabel: "Humidity ratio (kg/kg)"
+  title: "Labeled ITU index zone"
+  output: "index_zone_itu_labeled.png"
+  dpi: 180
+
+isolines:
+  relative_humidity:
+    enabled: true
+    values: [0.2, 0.4, 0.6, 0.8, 1.0]
+    color: "#666666"
+    linestyle: "-"
+    linewidth: 0.6
+    alpha: 0.45
+
+indexes:
+  - index: ITU
+    render:
+      isolines:
+        levels: [68, 72, 76, 80]
+        color: black
+        linewidth: 1.1
+        style: ":"
+        alpha: 0.80
+        label: true
+        label_fontsize: 8
+        label_fmt: "ITU {value:.0f}"
+
+index_zones:
+  - index: ITU
+    name: "ITU comfort band"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    linewidth: 1.0
+    alpha: 0.35
+    show_label: true
+    label: "ITU comfort"
+    label_position: auto
+    label_color: "#2F3A2F"
+    label_fontsize: 11
+    label_fontweight: bold
+    label_rotation: 65
+
+points:
+  - label: "Example point"
+    t: 28
+    rh: 0.65
+    marker: "o"
+    color: black

--- a/src/psychchart/config/zones.py
+++ b/src/psychchart/config/zones.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from .base import StrictModel
 from .utils import normalize_rh
@@ -116,15 +116,59 @@ class Zone(StrictModel):
 
 class IndexZone(StrictModel):
     """
-    Definition of a semantic zone derived from an index range.
+    Definition of a semantic zone derived from an index interval.
 
-    This model describes regions obtained from intervals of a computed scalar
-    index such as ITU, THI, HLI, or another registered indicator.
+    An index zone represents the subset of the psychrometric domain where a
+    computed scalar index lies within a prescribed numerical interval. It is
+    different from a geometric :class:`Zone`: its shape is not declared by
+    vertices, but derived from the index field evaluated over the valid chart
+    domain.
     """
 
     index: str
     name: str
     range: Tuple[float, float]
+
     color: str = "gray"
+    facecolor: Optional[str] = None
+    edgecolor: Optional[str] = None
+    linewidth: float = 0.0
     alpha: float = 0.3
+
+    show_label: bool = False
+    label: Optional[str] = None
+    label_position: str = "auto"
+    label_t: Optional[float] = None
+    label_rh: Optional[float] = None
+    label_color: Optional[str] = None
+    label_fontsize: float = 9.0
+    label_fontweight: Optional[str] = None
+    label_rotation: float = 0.0
+    label_bbox: Optional[Dict[str, Any]] = None
+
     parameters: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("label_rh", mode="before")
+    @classmethod
+    def validate_label_rh(cls, value: Any) -> float | None:
+        """Normalize optional label relative humidity to fraction."""
+        if value is None:
+            return value
+        return normalize_rh(value)
+
+    @model_validator(mode="after")
+    def validate_range_and_label(self) -> "IndexZone":
+        """Validate interval ordering and manual label placement."""
+        lower, upper = self.range
+        if lower >= upper:
+            raise ValueError("IndexZone 'range' must satisfy lower < upper")
+
+        if self.label_position not in {"auto", "manual"}:
+            raise ValueError("IndexZone 'label_position' must be 'auto' or 'manual'")
+
+        if self.label_position == "manual" and (self.label_t is None or self.label_rh is None):
+            raise ValueError(
+                "Manual IndexZone label placement requires both 'label_t' and 'label_rh'"
+            )
+
+        return self

--- a/src/psychchart/plot/indexes.py
+++ b/src/psychchart/plot/indexes.py
@@ -213,6 +213,73 @@ def _draw_index_field_labels(ax: Axes, layer, field_cfg, levels, labels, pressur
         )
 
 
+def _auto_index_zone_label_position(
+    ax: Axes,
+    layer,
+    mask: np.ndarray,
+) -> tuple[float | None, float | None]:
+    """Estimate a representative in-domain label point for an index-zone mask."""
+    x_min, x_max = ax.get_xlim()
+    y_min, y_max = ax.get_ylim()
+
+    visible_mask = (
+        mask
+        & np.isfinite(layer.X)
+        & np.isfinite(layer.Y)
+        & (layer.X >= x_min)
+        & (layer.X <= x_max)
+        & (layer.Y >= y_min)
+        & (layer.Y <= y_max)
+    )
+
+    if not np.any(visible_mask):
+        return None, None
+
+    return (
+        float(np.nanmedian(layer.X[visible_mask])),
+        float(np.nanmedian(layer.Y[visible_mask])),
+    )
+
+
+def _manual_index_zone_label_position(chart, zone) -> tuple[float | None, float | None]:
+    """Resolve a manual index-zone label position from T/RH coordinates."""
+    if zone.label_t is None or zone.label_rh is None:
+        return None, None
+    return (
+        float(zone.label_t),
+        float(Psychrometrics.humidity_ratio(zone.label_t, zone.label_rh, chart.cfg.pressure)),
+    )
+
+
+def _draw_index_zone_label(chart, ax: Axes, layer, zone, mask: np.ndarray) -> None:
+    """Draw an optional label inside an index-derived zone."""
+    if not getattr(zone, "show_label", False):
+        return
+
+    if zone.label_position == "manual":
+        x, y = _manual_index_zone_label_position(chart, zone)
+    else:
+        x, y = _auto_index_zone_label_position(ax, layer, mask)
+
+    if x is None or y is None:
+        return
+
+    color = zone.label_color or zone.edgecolor or zone.color
+    ax.text(
+        x,
+        y,
+        zone.label or zone.name,
+        fontsize=zone.label_fontsize,
+        color=color,
+        fontweight=zone.label_fontweight or "normal",
+        rotation=zone.label_rotation,
+        bbox=zone.label_bbox,
+        ha="center",
+        va="center",
+        zorder=ZORDER["zone_edge"] + 0.1,
+    )
+
+
 # =============================================================================
 # Continuous index fields (heatmaps)
 # =============================================================================
@@ -355,32 +422,48 @@ def _draw_index_zone(chart, ax: Axes, zone):
     if not hasattr(zone, "range") or len(zone.range) != 2:
         raise ValueError(f"Invalid zone range for index '{zone.index}'")
 
-    mask = (layer.Z >= zone.range[0]) & (layer.Z <= zone.range[1])
+    lower, upper = zone.range
+    mask = (layer.Z >= lower) & (layer.Z <= upper)
+    facecolor = zone.facecolor or zone.color
 
     ax.contourf(
         layer.X,
         layer.Y,
         mask,
         levels=[0.5, 1],
-        colors=[zone.color],
+        colors=[facecolor],
         alpha=zone.alpha,
         zorder=ZORDER["index_zone"],
     )
 
-    if not hasattr(chart, "_index_zone_counter"):
-        chart._index_zone_counter = 0
+    if zone.edgecolor and zone.linewidth > 0:
+        ax.contour(
+            layer.X,
+            layer.Y,
+            mask,
+            levels=[0.5],
+            colors=[zone.edgecolor],
+            linewidths=zone.linewidth,
+            zorder=ZORDER["zone_edge"],
+        )
 
-    ax.text(
-        0.01,
-        0.99 - 0.05 * chart._index_zone_counter,
-        f"{zone.index}: {zone.name}",
-        transform=ax.transAxes,
-        fontsize=9,
-        verticalalignment="top",
-        zorder=ZORDER["zone_edge"],
-    )
+    _draw_index_zone_label(chart, ax, layer, zone, mask)
 
-    chart._index_zone_counter += 1
+    if not zone.show_label:
+        if not hasattr(chart, "_index_zone_counter"):
+            chart._index_zone_counter = 0
+
+        ax.text(
+            0.01,
+            0.99 - 0.05 * chart._index_zone_counter,
+            f"{zone.index}: {zone.name}",
+            transform=ax.transAxes,
+            fontsize=9,
+            verticalalignment="top",
+            zorder=ZORDER["zone_edge"],
+        )
+
+        chart._index_zone_counter += 1
 
 
 def _draw_operational_overlays(chart, ax: Axes) -> None:

--- a/tests/test_index_zones.py
+++ b/tests/test_index_zones.py
@@ -1,0 +1,145 @@
+import matplotlib.pyplot as plt
+import pytest
+
+from psychchart import PsychChart, load_chart_config
+from psychchart.config import AppConfig, IndexZone
+
+
+def _minimal_chart_config():
+    """Return required ChartConfig fields for root-model validation tests."""
+    return {
+        "t_min": 10,
+        "t_max": 45,
+        "y_min": 0.0,
+        "y_max": 0.035,
+        "pressure": 101325,
+        "xlabel": "Dry-bulb temperature (°C)",
+        "ylabel": "Humidity ratio (kg/kg dry air)",
+        "output": "index_zone_test.png",
+        "dpi": 150,
+    }
+
+
+def test_index_zone_accepts_styling_and_internal_label_options():
+    """IndexZone should validate the full style and label schema."""
+    zone = IndexZone(
+        index="ITU",
+        name="comfort",
+        range=(68, 72),
+        facecolor="#A8E67A",
+        edgecolor="#5B8F3A",
+        linewidth=1.1,
+        alpha=0.38,
+        show_label=True,
+        label="ITU",
+        label_position="manual",
+        label_t=25.5,
+        label_rh=55,
+        label_color="#2F3A2F",
+        label_fontsize=12,
+        label_fontweight="bold",
+        label_rotation=72,
+    )
+
+    assert zone.range == (68, 72)
+    assert zone.label_rh == pytest.approx(0.55)
+    assert zone.facecolor == "#A8E67A"
+    assert zone.show_label is True
+
+
+def test_index_zone_rejects_invalid_interval_order():
+    """IndexZone intervals must have lower < upper."""
+    with pytest.raises(ValueError):
+        IndexZone(index="ITU", name="invalid", range=(72, 68))
+
+
+def test_index_zone_manual_label_requires_coordinates():
+    """Manual label placement must be explicit and reproducible."""
+    with pytest.raises(ValueError):
+        IndexZone(
+            index="ITU",
+            name="comfort",
+            range=(68, 72),
+            show_label=True,
+            label_position="manual",
+            label_t=25.0,
+        )
+
+
+def test_app_config_accepts_labeled_index_zone():
+    """Root configuration should accept labeled index-derived zones."""
+    cfg = AppConfig.model_validate(
+        {
+            "chart": _minimal_chart_config(),
+            "index_zones": [
+                {
+                    "index": "ITU",
+                    "name": "ITU comfort zone",
+                    "range": [68, 72],
+                    "facecolor": "#A8E67A",
+                    "edgecolor": "#5B8F3A",
+                    "linewidth": 1.1,
+                    "alpha": 0.38,
+                    "show_label": True,
+                    "label": "ITU",
+                    "label_position": "auto",
+                    "label_color": "#2F3A2F",
+                    "label_fontsize": 12,
+                    "label_fontweight": "bold",
+                    "label_rotation": 72,
+                }
+            ],
+        }
+    )
+
+    assert len(cfg.index_zones) == 1
+    assert cfg.index_zones[0].label == "ITU"
+
+
+def test_labeled_index_zone_render_smoke(tmp_path):
+    """Rendering an index-zone fill with an internal label should not fail."""
+    yaml = """
+chart:
+  t_min: 10
+  t_max: 45
+  y_min: 0.0
+  y_max: 0.035
+  output: index_zone_smoke.png
+
+indexes:
+  - index: ITU
+    render:
+      isolines:
+        levels: [68, 72]
+        color: "black"
+        linewidth: 0.8
+        label: true
+        label_fmt: "ITU {value:.0f}"
+
+index_zones:
+  - index: ITU
+    name: "ITU comfort zone"
+    range: [68, 72]
+    facecolor: "#A8E67A"
+    edgecolor: "#5B8F3A"
+    linewidth: 1.0
+    alpha: 0.35
+    show_label: true
+    label: "ITU"
+    label_position: auto
+    label_color: "#2F3A2F"
+    label_fontsize: 10
+    label_fontweight: bold
+    label_rotation: 70
+"""
+    cfg_file = tmp_path / "index_zone.yaml"
+    cfg_file.write_text(yaml, encoding="utf-8")
+
+    data = load_chart_config(cfg_file)
+    chart = PsychChart(**data)
+    chart.draw()
+    try:
+        labels = {text.get_text() for text in chart.ax.texts}
+        assert "ITU" in labels
+    finally:
+        plt.close(chart.fig)


### PR DESCRIPTION
## Summary

This PR extracts the useful, focused part of the old `feature/index-zone-labels` branch into a clean branch based on the current `main`.

It adds support for styled labels inside index-derived zones (`index_zones`) without bringing the older duplicated documentation or replacing the already-stabilized index field label renderer.

## Changes

- Extends `IndexZone` with optional styling and label fields:
  - `facecolor`
  - `edgecolor`
  - `linewidth`
  - `show_label`
  - `label`
  - `label_position`
  - `label_t`
  - `label_rh`
  - `label_color`
  - `label_fontsize`
  - `label_fontweight`
  - `label_rotation`
  - `label_bbox`
- Validates `range` ordering.
- Validates manual label placement coordinates.
- Normalizes manual `label_rh` from percent or fraction.
- Draws optional contours for index zones when `edgecolor` and `linewidth` are set.
- Draws labels inside the derived index-zone mask when `show_label: true`.
- Preserves the old corner text behavior when `show_label` is false.
- Adds a minimal example: `examples/index_zone_itu_labeled.yaml`.
- Adds tests for schema validation and smoke rendering.

## Why

Index field labels describe semantic intervals across a continuous field. `index_zones` are different: they are explicit overlay regions derived from a selected index interval. This PR gives those derived zones their own label and style controls while keeping the existing index-field label feature intact.

## Validation

Recommended local validation:

```bash
pytest
psychchart examples/index_zone_itu_labeled.yaml
psychchart examples/itu_field_labels.yaml
psychchart examples/operational_overlay_minimal.yaml
```

## Scope

Focused feature extraction only. No legacy docs from the old branch were imported.