### PR TITLE
Add standalone intervention zone layer

### DIFF
--- a/src/psychchart/config/intervention_zones.py
+++ b/src/psychchart/config/intervention_zones.py
@@ -1,0 +1,127 @@
+"""Configuration models for psychrometric intervention zones."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from .base import StrictModel
+
+
+class ComfortReferenceConfig(StrictModel):
+    """Reference rectangle used to document the target comfort region."""
+
+    t_min: float | None = None
+    t_max: float | None = None
+    w_min: float | None = None
+    w_max: float | None = None
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> "ComfortReferenceConfig":
+        """Validate optional comfort-reference bounds."""
+        if self.t_min is not None and self.t_max is not None and self.t_min >= self.t_max:
+            raise ValueError("comfort_reference.t_min must be smaller than t_max")
+        if self.w_min is not None and self.w_max is not None and self.w_min >= self.w_max:
+            raise ValueError("comfort_reference.w_min must be smaller than w_max")
+        return self
+
+
+class InterventionConditionConfig(StrictModel):
+    """Threshold predicates evaluated in dry-bulb temperature and humidity ratio."""
+
+    t_lt: float | None = None
+    t_lte: float | None = None
+    t_gt: float | None = None
+    t_gte: float | None = None
+    w_lt: float | None = None
+    w_lte: float | None = None
+    w_gt: float | None = None
+    w_gte: float | None = None
+
+    @model_validator(mode="after")
+    def validate_predicates(self) -> "InterventionConditionConfig":
+        """Require at least one active predicate."""
+        if not any(value is not None for value in self.model_dump().values()):
+            raise ValueError("An intervention condition must define at least one predicate")
+        return self
+
+
+class InterventionLabelConfig(StrictModel):
+    """Optional text placement and style for an intervention rule."""
+
+    enabled: bool = True
+    position: tuple[float, float] | None = None
+    fontsize: float = 9.0
+    color: str = "black"
+    alpha: float = Field(default=0.78, ge=0.0, le=1.0)
+    fontweight: str | None = None
+    ha: str = "center"
+    va: str = "center"
+
+
+class InterventionVectorStyleConfig(StrictModel):
+    """Visual style for a physical displacement vector."""
+
+    enabled: bool = True
+    color: str = "black"
+    alpha: float = Field(default=0.58, ge=0.0, le=1.0)
+    linewidth: float = Field(default=1.1, ge=0.0)
+    head_width: float = Field(default=0.00045, gt=0.0)
+    head_length: float = Field(default=0.35, gt=0.0)
+    width: float = Field(default=0.000025, gt=0.0)
+    position: tuple[float, float] | None = None
+
+
+class InterventionRuleConfig(StrictModel):
+    """One intervention region evaluated as a boolean mask in T-W space."""
+
+    name: str
+    label: str
+    when: InterventionConditionConfig
+    kind: Literal["recommended", "inappropriate"] = "recommended"
+    reason: str | None = None
+    vector: tuple[float, float] | None = None
+    vector_style: InterventionVectorStyleConfig = Field(default_factory=InterventionVectorStyleConfig)
+    facecolor: str = "#cccccc"
+    edgecolor: str = "#666666"
+    alpha: float = Field(default=0.20, ge=0.0, le=1.0)
+    linewidth: float = Field(default=0.8, ge=0.0)
+    linestyle: str = "-"
+    hatch: str | None = None
+    label_style: InterventionLabelConfig = Field(default_factory=InterventionLabelConfig)
+    priority: int = 0
+    zorder: float | None = None
+
+
+class InterventionZonesConfig(StrictModel):
+    """Root configuration for explicit psychrometric intervention zones."""
+
+    enabled: bool = True
+    method: Literal["operational_psychrometric"] = "operational_psychrometric"
+    comfort_reference: ComfortReferenceConfig | None = None
+    n_t: int = Field(default=420, ge=20)
+    n_w: int = Field(default=320, ge=20)
+    clip_to_saturation: bool = True
+    alpha_scale: float = Field(default=1.0, ge=0.0, le=1.0)
+    zorder: float = 1.35
+    inappropriate_zorder: float = 1.70
+    label_zorder: float = 4.60
+    vector_zorder: float = 4.70
+    show_labels: bool = True
+    show_vectors: bool = True
+    show_boundaries: bool = True
+    rules: list[InterventionRuleConfig] = Field(default_factory=list)
+    inappropriate_rules: list[InterventionRuleConfig] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def normalize_inappropriate_rules(self) -> "InterventionZonesConfig":
+        """Force rules declared under inappropriate_rules to the inappropriate kind."""
+        for rule in self.inappropriate_rules:
+            rule.kind = "inappropriate"
+        return self
+
+    @property
+    def all_rules(self) -> list[InterventionRuleConfig]:
+        """Return all rules sorted by priority."""
+        return sorted([*self.rules, *self.inappropriate_rules], key=lambda item: item.priority)

--- a/src/psychchart/plot/intervention_zones.py
+++ b/src/psychchart/plot/intervention_zones.py
@@ -1,0 +1,323 @@
+"""Explicit psychrometric intervention-zone renderer.
+
+This module renders declarative intervention regions on top of an existing
+psychrometric chart. The layer is intentionally separate from index rendering
+and from the declarative accumulated-load operational policy engine.
+
+It answers a geometric management question in T-W space:
+
+    Which physical intervention tends to move this state toward comfort?
+
+Examples include ventilation, dehumidification, mechanical cooling, evaporative
+cooling, and hachured regions marking interventions that should be avoided.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.patches import FancyArrow, Patch
+
+from psychchart.config.intervention_zones import (
+    InterventionConditionConfig,
+    InterventionRuleConfig,
+    InterventionZonesConfig,
+)
+from psychchart.psychrometrics import Psychrometrics
+
+
+def axis_domain(ax: Axes) -> tuple[float, float, float, float]:
+    """Return the current T-W plotting domain from an Axes object."""
+    t_min, t_max = ax.get_xlim()
+    w_min, w_max = ax.get_ylim()
+    return float(t_min), float(t_max), float(w_min), float(w_max)
+
+
+def condition_mask(
+    T: np.ndarray,
+    W: np.ndarray,
+    condition: InterventionConditionConfig,
+) -> np.ndarray:
+    """Evaluate an intervention rule condition over a T-W grid."""
+    mask = np.ones_like(T, dtype=bool)
+
+    if condition.t_lt is not None:
+        mask &= T < condition.t_lt
+    if condition.t_lte is not None:
+        mask &= T <= condition.t_lte
+    if condition.t_gt is not None:
+        mask &= T > condition.t_gt
+    if condition.t_gte is not None:
+        mask &= T >= condition.t_gte
+
+    if condition.w_lt is not None:
+        mask &= W < condition.w_lt
+    if condition.w_lte is not None:
+        mask &= W <= condition.w_lte
+    if condition.w_gt is not None:
+        mask &= W > condition.w_gt
+    if condition.w_gte is not None:
+        mask &= W >= condition.w_gte
+
+    return mask
+
+
+def rule_center_from_condition(
+    rule: InterventionRuleConfig,
+    *,
+    t_min: float,
+    t_max: float,
+    w_min: float,
+    w_max: float,
+) -> tuple[float, float]:
+    """Estimate a useful label/vector center for a threshold-defined region."""
+    condition = rule.when
+
+    left = t_min
+    right = t_max
+    bottom = w_min
+    top = w_max
+
+    if condition.t_gt is not None:
+        left = max(left, condition.t_gt)
+    if condition.t_gte is not None:
+        left = max(left, condition.t_gte)
+    if condition.t_lt is not None:
+        right = min(right, condition.t_lt)
+    if condition.t_lte is not None:
+        right = min(right, condition.t_lte)
+
+    if condition.w_gt is not None:
+        bottom = max(bottom, condition.w_gt)
+    if condition.w_gte is not None:
+        bottom = max(bottom, condition.w_gte)
+    if condition.w_lt is not None:
+        top = min(top, condition.w_lt)
+    if condition.w_lte is not None:
+        top = min(top, condition.w_lte)
+
+    x = 0.5 * (t_min + t_max) if left >= right else 0.5 * (left + right)
+    y = 0.5 * (w_min + w_max) if bottom >= top else 0.5 * (bottom + top)
+
+    return float(x), float(y)
+
+
+def draw_label(
+    ax: Axes,
+    rule: InterventionRuleConfig,
+    x: float,
+    y: float,
+    *,
+    zorder: float,
+) -> object | None:
+    """Draw an optional rule label and return the text artist."""
+    style = rule.label_style
+    if not style.enabled:
+        return None
+
+    if style.position is not None:
+        x, y = style.position
+
+    text = rule.label
+    if rule.kind == "inappropriate" and rule.reason:
+        text = f"{rule.label}\n{rule.reason}"
+
+    return ax.text(
+        x,
+        y,
+        text,
+        ha=style.ha,
+        va=style.va,
+        fontsize=style.fontsize,
+        color=style.color,
+        alpha=style.alpha,
+        fontweight=style.fontweight,
+        zorder=zorder,
+        clip_on=True,
+    )
+
+
+def draw_vector(
+    ax: Axes,
+    rule: InterventionRuleConfig,
+    x: float,
+    y: float,
+    *,
+    zorder: float,
+) -> FancyArrow | None:
+    """Draw an optional physical displacement vector for a rule."""
+    if rule.vector is None or not rule.vector_style.enabled:
+        return None
+
+    style = rule.vector_style
+    if style.position is not None:
+        x, y = style.position
+
+    dx, dy = rule.vector
+    return ax.arrow(
+        x,
+        y,
+        dx,
+        dy,
+        color=style.color,
+        alpha=style.alpha,
+        linewidth=style.linewidth,
+        width=style.width,
+        head_width=style.head_width,
+        head_length=style.head_length,
+        length_includes_head=True,
+        zorder=zorder,
+        clip_on=True,
+    )
+
+
+def draw_rule_region(
+    ax: Axes,
+    T_grid: np.ndarray,
+    W_grid: np.ndarray,
+    rule: InterventionRuleConfig,
+    config: InterventionZonesConfig,
+    *,
+    t_min: float,
+    t_max: float,
+    w_min: float,
+    w_max: float,
+) -> list[object]:
+    """Draw one operational rule as a filled mask plus optional annotations."""
+    artists: list[object] = []
+    mask = condition_mask(T_grid, W_grid, rule.when)
+    mask &= np.isfinite(T_grid) & np.isfinite(W_grid)
+    if not np.any(mask):
+        return artists
+
+    field = np.where(mask, 1.0, np.nan)
+    is_bad = rule.kind == "inappropriate"
+    zorder = rule.zorder if rule.zorder is not None else (
+        config.inappropriate_zorder if is_bad else config.zorder
+    )
+
+    contour = ax.contourf(
+        T_grid,
+        W_grid,
+        field,
+        levels=[0.5, 1.5],
+        colors=[rule.facecolor],
+        alpha=rule.alpha * config.alpha_scale,
+        hatches=[rule.hatch] if rule.hatch else None,
+        zorder=zorder,
+    )
+    artists.append(contour)
+
+    if config.show_boundaries and rule.linewidth > 0:
+        boundary = ax.contour(
+            T_grid,
+            W_grid,
+            np.where(mask, 1.0, 0.0),
+            levels=[0.5],
+            colors=[rule.edgecolor],
+            linewidths=[rule.linewidth],
+            linestyles=[rule.linestyle],
+            alpha=max(rule.alpha, 0.35),
+            zorder=zorder + 0.05,
+        )
+        artists.append(boundary)
+
+    x, y = rule_center_from_condition(
+        rule,
+        t_min=t_min,
+        t_max=t_max,
+        w_min=w_min,
+        w_max=w_max,
+    )
+
+    if config.show_labels:
+        label_artist = draw_label(ax, rule, x, y, zorder=config.label_zorder)
+        if label_artist is not None:
+            artists.append(label_artist)
+
+    if config.show_vectors and not is_bad:
+        arrow_artist = draw_vector(ax, rule, x, y, zorder=config.vector_zorder)
+        if arrow_artist is not None:
+            artists.append(arrow_artist)
+
+    artists.append(
+        Patch(
+            facecolor=rule.facecolor,
+            edgecolor=rule.edgecolor,
+            alpha=min(rule.alpha * config.alpha_scale, 1.0),
+            hatch=rule.hatch,
+            label=rule.label,
+        )
+    )
+
+    return artists
+
+
+def physical_grid(
+    *,
+    t_min: float,
+    t_max: float,
+    w_min: float,
+    w_max: float,
+    pressure: float,
+    n_t: int,
+    n_w: int,
+    clip_to_saturation: bool,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a Cartesian T-W grid optionally masked above saturation."""
+    t_values = np.linspace(t_min, t_max, n_t)
+    w_values = np.linspace(w_min, w_max, n_w)
+    T_grid, W_grid = np.meshgrid(t_values, w_values)
+
+    if clip_to_saturation:
+        W_sat = Psychrometrics.humidity_ratio(T_grid, np.ones_like(T_grid), pressure)
+        W_grid = np.where(W_grid <= W_sat, W_grid, np.nan)
+
+    return T_grid, W_grid
+
+
+def draw_intervention_zones(
+    ax: Axes,
+    config: InterventionZonesConfig | None,
+    *,
+    pressure: float,
+) -> list[object]:
+    """Draw explicit intervention zones on an existing psychrometric axes."""
+    if config is None or not config.enabled:
+        return []
+
+    rules: Iterable[InterventionRuleConfig] = config.all_rules
+    if not rules:
+        return []
+
+    t_min, t_max, w_min, w_max = axis_domain(ax)
+    T_grid, W_grid = physical_grid(
+        t_min=t_min,
+        t_max=t_max,
+        w_min=w_min,
+        w_max=w_max,
+        pressure=pressure,
+        n_t=config.n_t,
+        n_w=config.n_w,
+        clip_to_saturation=config.clip_to_saturation,
+    )
+
+    artists: list[object] = []
+    for rule in rules:
+        artists.extend(
+            draw_rule_region(
+                ax,
+                T_grid,
+                W_grid,
+                rule,
+                config,
+                t_min=t_min,
+                t_max=t_max,
+                w_min=w_min,
+                w_max=w_max,
+            )
+        )
+
+    return artists

--- a/tests/test_intervention_zones.py
+++ b/tests/test_intervention_zones.py
@@ -1,0 +1,138 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from psychchart.config.intervention_zones import (
+    ComfortReferenceConfig,
+    InterventionConditionConfig,
+    InterventionRuleConfig,
+    InterventionZonesConfig,
+)
+from psychchart.plot.intervention_zones import (
+    condition_mask,
+    draw_intervention_zones,
+    physical_grid,
+    rule_center_from_condition,
+)
+
+
+def test_intervention_condition_requires_at_least_one_predicate():
+    """An intervention condition without predicates is ambiguous."""
+    with pytest.raises(ValueError):
+        InterventionConditionConfig()
+
+
+def test_comfort_reference_validates_bounds():
+    """Comfort reference bounds must be ordered when provided."""
+    with pytest.raises(ValueError):
+        ComfortReferenceConfig(t_min=30.0, t_max=20.0)
+
+    with pytest.raises(ValueError):
+        ComfortReferenceConfig(w_min=0.020, w_max=0.010)
+
+
+def test_condition_mask_combines_temperature_and_humidity_predicates():
+    """Rule masks should combine T and W predicates with logical AND."""
+    T = np.array([[20.0, 30.0], [35.0, 40.0]])
+    W = np.array([[0.010, 0.018], [0.022, 0.030]])
+    condition = InterventionConditionConfig(t_gte=30.0, w_gte=0.020)
+
+    mask = condition_mask(T, W, condition)
+
+    assert mask.tolist() == [[False, False], [True, True]]
+
+
+def test_inappropriate_rules_are_normalized():
+    """Rules declared under inappropriate_rules should be marked accordingly."""
+    cfg = InterventionZonesConfig(
+        inappropriate_rules=[
+            InterventionRuleConfig(
+                name="avoid_evaporative",
+                label="Avoid evaporative cooling",
+                when=InterventionConditionConfig(t_gte=30.0, w_gte=0.020),
+            )
+        ]
+    )
+
+    assert cfg.inappropriate_rules[0].kind == "inappropriate"
+    assert cfg.all_rules[0].kind == "inappropriate"
+
+
+def test_rule_center_from_condition_uses_threshold_bounds():
+    """Rule center should be estimated from active threshold bounds."""
+    rule = InterventionRuleConfig(
+        name="ventilation",
+        label="Ventilation",
+        when=InterventionConditionConfig(t_gte=28.0, t_lt=36.0, w_lt=0.020),
+    )
+
+    x, y = rule_center_from_condition(
+        rule,
+        t_min=10.0,
+        t_max=45.0,
+        w_min=0.0,
+        w_max=0.035,
+    )
+
+    assert x == pytest.approx(32.0)
+    assert y == pytest.approx(0.010)
+
+
+def test_physical_grid_can_clip_above_saturation():
+    """Grid clipping should mask humidity-ratio values above saturation."""
+    T, W = physical_grid(
+        t_min=10.0,
+        t_max=20.0,
+        w_min=0.0,
+        w_max=0.080,
+        pressure=101325.0,
+        n_t=8,
+        n_w=8,
+        clip_to_saturation=True,
+    )
+
+    assert T.shape == (8, 8)
+    assert W.shape == (8, 8)
+    assert np.isnan(W).any()
+
+
+def test_draw_intervention_zones_smoke():
+    """Renderer should draw recommended and inappropriate rules without failing."""
+    fig, ax = plt.subplots()
+    ax.set_xlim(10.0, 45.0)
+    ax.set_ylim(0.0, 0.035)
+
+    cfg = InterventionZonesConfig(
+        n_t=32,
+        n_w=24,
+        rules=[
+            InterventionRuleConfig(
+                name="ventilation",
+                label="Ventilation",
+                when=InterventionConditionConfig(t_gte=28.0, w_lt=0.020),
+                vector=(-3.0, 0.0),
+                facecolor="#A8E67A",
+                edgecolor="#5B8F3A",
+            )
+        ],
+        inappropriate_rules=[
+            InterventionRuleConfig(
+                name="avoid_evaporative",
+                label="Avoid evaporative",
+                reason="hot and humid",
+                when=InterventionConditionConfig(t_gte=30.0, w_gte=0.020),
+                hatch="///",
+                facecolor="#fdae61",
+                edgecolor="#7f0000",
+            )
+        ],
+    )
+
+    try:
+        artists = draw_intervention_zones(ax, cfg, pressure=101325.0)
+        assert artists
+        text_values = {text.get_text() for text in ax.texts}
+        assert "Ventilation" in text_values
+        assert "Avoid evaporative\nhot and humid" in text_values
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
## Summary

This PR extracts a focused intervention-zone base layer into a clean branch based on the current `main`.

It adds:

- configuration models for intervention zones;
- a standalone T-W renderer for threshold-defined intervention regions;
- labels, hatches, vectors and saturation clipping support;
- direct unit and smoke tests.

## Scope

This PR does not wire the new layer into the main YAML/rendering pipeline yet. It only adds the standalone models, renderer and tests.

A follow-up PR can integrate the layer into `AppConfig` and `PsychChart.draw()` after this base behavior is validated.

## Validation

```bash
pytest tests/test_intervention_zones.py
pytest
```