### PR TITLE
Integrate intervention zones into YAML render pipeline

### DIFF
--- a/examples/intervention_zones_minimal.yaml
+++ b/examples/intervention_zones_minimal.yaml
@@ -1,0 +1,84 @@
+chart:
+  t_min: 10
+  t_max: 45
+  y_min: 0.0
+  y_max: 0.035
+  pressure: 101325
+  xlabel: "Dry-bulb temperature (°C)"
+  ylabel: "Humidity ratio (kg/kg)"
+  title: "Explicit intervention zones"
+  output: "intervention_zones_minimal.png"
+  dpi: 180
+
+isolines:
+  relative_humidity:
+    enabled: true
+    values: [0.2, 0.4, 0.6, 0.8, 1.0]
+    color: "#666666"
+    linestyle: "-"
+    linewidth: 0.6
+    alpha: 0.45
+
+intervention_zones:
+  enabled: true
+  n_t: 120
+  n_w: 90
+  show_labels: true
+  show_vectors: true
+  show_boundaries: true
+
+  rules:
+    - name: ventilation
+      label: "Ventilation"
+      when:
+        t_gte: 28
+        w_lt: 0.020
+      vector: [-3.0, 0.0]
+      facecolor: "#A8E67A"
+      edgecolor: "#5B8F3A"
+      alpha: 0.25
+      linewidth: 1.0
+      label_style:
+        fontsize: 9
+        color: "#1f2937"
+        fontweight: bold
+
+    - name: dehumidification
+      label: "Reduce humidity"
+      when:
+        w_gte: 0.020
+        t_lt: 32
+      vector: [0.0, -0.004]
+      facecolor: "#93c5fd"
+      edgecolor: "#1d4ed8"
+      alpha: 0.22
+      linewidth: 1.0
+      label_style:
+        fontsize: 9
+        color: "#1e3a8a"
+        fontweight: bold
+
+  inappropriate_rules:
+    - name: avoid_evaporative_hot_humid
+      label: "Avoid evaporative"
+      reason: "hot and humid"
+      when:
+        t_gte: 32
+        w_gte: 0.020
+      facecolor: "#fdae61"
+      edgecolor: "#7f0000"
+      alpha: 0.18
+      linewidth: 1.0
+      hatch: "///"
+      label_style:
+        fontsize: 9
+        color: "#7f0000"
+        fontweight: bold
+
+points:
+  - label: "Hot-humid example"
+    t: 34
+    rh: 0.75
+    marker: "o"
+    color: black
+    show_label: true

--- a/src/psychchart/config/__init__.py
+++ b/src/psychchart/config/__init__.py
@@ -4,138 +4,25 @@ Public configuration API for ``psychchart``.
 This package centralizes the strongly typed configuration models used across
 the ``psychchart`` project. The exported classes form the public interface for
 configuration loading, validation, normalization, and runtime integration.
-
-The design intentionally exposes a small set of well-defined models rather
-than requiring downstream code to import from many internal modules. This
-improves readability, reduces coupling, and makes the configuration layer
-easier to use from loaders, command-line interfaces, notebooks, and tests.
-
-Architecture
-------------
-The configuration package is organized by responsibility:
-
-- ``base``:
-  strict shared validation behavior
-- ``chart``:
-  global chart-level configuration
-- ``isolines``:
-  isoline family definitions
-- ``zones``:
-  geometric and index-derived zones
-- ``points``:
-  reference points
-- ``indexes``:
-  computed index configuration and rendering
-- ``observations``:
-  legacy observational dataset configuration
-- ``overlays``:
-  legacy temporal trajectory overlays
-- ``data_layers``:
-  canonical unified configuration for dataset-driven layers
-- ``app``:
-  validated root application configuration
-- ``paths``:
-  ordered trajectory in psychrometric space
-
-Notes
------
-This module is intentionally lightweight. It does not define new models by
-itself; instead, it re-exports the public configuration classes so users can
-import them from a single, stable location.
-
-Examples
---------
-Import the public configuration models from one place:
-
->>> from psychchart.config import AppConfig, ChartConfig, IsoSet
->>> ChartConfig.__name__
-'ChartConfig'
-
-Validate a minimal root configuration:
-
->>> raw = {
-...     "chart": {
-...         "t_min": 0.0,
-...         "t_max": 50.0,
-...         "pressure": 101325.0,
-...         "xlabel": "Dry-bulb temperature (°C)",
-...         "ylabel": "Humidity ratio (kg/kg)",
-...         "output": "chart.png",
-...         "dpi": 150,
-...     }
-... }
->>> cfg = AppConfig.model_validate(raw)
->>> cfg.chart.output
-'chart.png'
 """
 
-# -----------------------------------------------------------------------------
-# Root application model
-# -----------------------------------------------------------------------------
-# ``AppConfig`` is the main entry point for validating the full merged
-# configuration document used by the runtime.
 from .app import AppConfig
-
-# -----------------------------------------------------------------------------
-# Global chart configuration
-# -----------------------------------------------------------------------------
-# ``ChartConfig`` stores domain limits, axis labels, export options, pressure,
-# and other chart-wide parameters.
 from .chart import ChartConfig
-
-# -----------------------------------------------------------------------------
-# Isoline configuration
-# -----------------------------------------------------------------------------
-# ``IsoSet`` defines a semantic family of isolines, such as relative humidity,
-# enthalpy, or other chart overlays represented as contour-like line groups.
 from .isolines import IsoSet
-
-# -----------------------------------------------------------------------------
-# Zone configuration
-# -----------------------------------------------------------------------------
-# ``Zone`` represents explicit geometric zones in chart space.
-# ``IndexZone`` represents semantic zones derived from scalar index intervals.
 from .zones import Zone, IndexZone
-
-# -----------------------------------------------------------------------------
-# Point configuration
-# -----------------------------------------------------------------------------
-# ``Point`` defines a single annotated reference point in psychrometric space.
 from .points import Point
-
-# -----------------------------------------------------------------------------
-# Index configuration and rendering
-# -----------------------------------------------------------------------------
-# These classes define both the semantic identity of computed indices and the
-# way they can be rendered as continuous fields and/or isolines.
 from .indexes import (
     FieldRenderConfig,
     IsolineRenderConfig,
     IndexRenderConfig,
     IndexConfig,
 )
-
-# -----------------------------------------------------------------------------
-# Observational dataset configuration
-# -----------------------------------------------------------------------------
-# These classes describe dataset-based visual layers such as density fields and
-# data-driven scalar visualizations derived from observational files.
 from .observations import (
     DensityFieldConfig,
     DataIndexConfig,
     ObservationsConfig,
 )
-
-# -----------------------------------------------------------------------------
-# Temporal overlay configuration
-# -----------------------------------------------------------------------------
-# ``TemporalOverlayConfig`` describes time-ordered trajectories drawn over the
-# psychrometric chart.
 from .overlays import TemporalOverlayConfig
-
-# -----------------------------------------------------------------------------
-# Canonical unified data-layer configuration
-# -----------------------------------------------------------------------------
 from .data_layers import (
     ProjectionConfig,
     TemporalConfig,
@@ -149,45 +36,27 @@ from .data_layers import (
     AnnotateRenderConfig,
     DataLayerConfig,
 )
-
-# -----------------------------------------------------------------------------
-# Global declarative legend configuration.
-# -----------------------------------------------------------------------------
 from .legend import (
-        LegendPatchEntry,
-        LegendLineEntry,
-        LegendMarkerEntry,
-        LegendConfig,
+    LegendPatchEntry,
+    LegendLineEntry,
+    LegendMarkerEntry,
+    LegendConfig,
 )
-
-# -----------------------------------------------------------------------------
-# Shared strict validation base
-# -----------------------------------------------------------------------------
-# ``StrictModel`` is the common strict Pydantic base used by the public
-# configuration models.
 from .base import StrictModel
-
-# -----------------------------------------------------------------------------
-# Psychrometric path configuration
-# -----------------------------------------------------------------------------
-# ``PathConfig`` defines ordered trajectories in psychrometric space, including
-# optional scalar values for progressive color mapping.
 from .paths import PathConfig
-
-
-# -----------------------------------------------------------------------------
-#
-# -----------------------------------------------------------------------------
 from .operations import (
     OperationalOverlayConfig,
     OperationalProfileConfig,
 )
-# -----------------------------------------------------------------------------
-# Optional explicit public export list
-# -----------------------------------------------------------------------------
-# Defining ``__all__`` makes the public API explicit and communicates which
-# names are intended for external consumption. This is especially useful for
-# package users, static analysis tools, and documentation generation.
+from .intervention_zones import (
+    ComfortReferenceConfig,
+    InterventionConditionConfig,
+    InterventionLabelConfig,
+    InterventionVectorStyleConfig,
+    InterventionRuleConfig,
+    InterventionZonesConfig,
+)
+
 __all__: list[str] = [
     "AppConfig",
     "ChartConfig",
@@ -221,5 +90,11 @@ __all__: list[str] = [
     "LegendConfig",
     "OperationalOverlayConfig",
     "OperationalProfileConfig",
+    "ComfortReferenceConfig",
+    "InterventionConditionConfig",
+    "InterventionLabelConfig",
+    "InterventionVectorStyleConfig",
+    "InterventionRuleConfig",
+    "InterventionZonesConfig",
     "StrictModel",
 ]

--- a/src/psychchart/config/app.py
+++ b/src/psychchart/config/app.py
@@ -2,18 +2,8 @@
 Root configuration model for psychchart.
 
 This module defines the top-level validated application configuration used by
-the ``psychchart`` package.
-
-It provides the canonical entry point for configuration validation after the
-base profile and user YAML documents have been loaded and deep-merged. The
-root model centralizes the structure of the full configuration document and
-connects all major configuration sections, including chart settings, isolines,
-zones, points, indexes, legacy observations, legacy temporal overlays, and the
-canonical unified ``data_layers`` section.
-
-The main goal of this module is to ensure that the rest of the codebase can
-operate on a stable, strongly typed, and semantically normalized configuration
-object instead of raw nested dictionaries.
+``psychchart`` after base profiles and user YAML documents have been loaded and
+merged.
 """
 
 from __future__ import annotations
@@ -26,6 +16,7 @@ from .base import StrictModel
 from .chart import ChartConfig
 from .data_layers import DataLayerConfig
 from .indexes import IndexConfig
+from .intervention_zones import InterventionZonesConfig
 from .observations import ObservationsConfig
 from .overlays import TemporalOverlayConfig
 from .points import Point
@@ -43,9 +34,7 @@ from .operations import (
 # Legacy compatibility helpers
 # =============================================================================
 def _observation_to_data_layer(obs: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Convert one legacy ``observations`` entry into a canonical data layer.
-    """
+    """Convert one legacy ``observations`` entry into a canonical data layer."""
     fields: List[Dict[str, Any]] = []
     render: List[Dict[str, Any]] = []
 
@@ -129,9 +118,7 @@ def _observation_to_data_layer(obs: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _temporal_to_data_layer(overlay: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Convert one legacy ``temporal_overlays`` entry into a canonical data layer.
-    """
+    """Convert one legacy ``temporal_overlays`` entry into a canonical data layer."""
     render: List[Dict[str, Any]] = []
 
     if overlay.get("show_path", True):
@@ -205,15 +192,7 @@ def _temporal_to_data_layer(overlay: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _inject_default_operational_profile(data: Dict[str, Any]) -> None:
-    """
-    Inject the built-in dairy operational profile when it is referenced.
-
-    The operational layer is designed to be declarative, but most examples and
-    routine use cases should not need to repeat the full default dairy cooling
-    policy. When an overlay references ``dairy_cooling_default`` and the profile
-    is not explicitly provided, this helper inserts a validated default mapping
-    before Pydantic model validation.
-    """
+    """Inject the built-in dairy operational profile when it is referenced."""
     overlays = data.get("operational_overlays") or []
     if not overlays:
         return
@@ -240,14 +219,7 @@ def _inject_default_operational_profile(data: Dict[str, Any]) -> None:
 
 
 class AppConfig(StrictModel):
-    """
-    Root validated application configuration for ``psychchart``.
-
-    The canonical runtime-facing dataset layer is ``data_layers``. Legacy
-    ``observations`` and ``temporal_overlays`` are still accepted as input and
-    normalized into canonical data-layer definitions when ``data_layers`` is not
-    explicitly provided.
-    """
+    """Root validated application configuration for ``psychchart``."""
 
     chart: ChartConfig
     isolines: Dict[str, IsoSet] = Field(default_factory=dict)
@@ -263,13 +235,12 @@ class AppConfig(StrictModel):
 
     operational_profiles: dict[str, OperationalProfileConfig] = Field(default_factory=dict)
     operational_overlays: list[OperationalOverlayConfig] = Field(default_factory=list)
+    intervention_zones: InterventionZonesConfig | None = None
 
     @model_validator(mode="before")
     @classmethod
     def normalize_legacy_shapes(cls, data: Any) -> Any:
-        """
-        Normalize supported legacy configuration shapes before validation.
-        """
+        """Normalize supported legacy configuration shapes before validation."""
         if not isinstance(data, dict):
             raise TypeError("Top-level configuration must be a mapping/dict")
 
@@ -390,9 +361,7 @@ class AppConfig(StrictModel):
         return data
 
     def to_runtime_payload(self) -> Dict[str, Any]:
-        """
-        Convert the validated model into the canonical runtime payload.
-        """
+        """Convert the validated model into the canonical runtime payload."""
         return {
             "cfg": self.chart,
             "isolines": {
@@ -406,13 +375,12 @@ class AppConfig(StrictModel):
             "data_layers": self.data_layers,
             "operational_profiles": self.operational_profiles,
             "operational_overlays": self.operational_overlays,
+            "intervention_zones": self.intervention_zones,
         }
 
     @model_validator(mode="after")
     def validate_operational_sections(self):
-        """
-        Validate references between operational overlays and profiles.
-        """
+        """Validate references between operational overlays and profiles."""
         if not self.operational_overlays:
             return self
 

--- a/src/psychchart/plot/__init__.py
+++ b/src/psychchart/plot/__init__.py
@@ -1,3 +1,29 @@
-from .core import PsychChart
+"""Public plotting API."""
+
+from __future__ import annotations
+
+from matplotlib.axes import Axes
+
+from .core import PsychChart as _BasePsychChart
+from .intervention_zones import draw_intervention_zones
+
+
+class PsychChart(_BasePsychChart):
+    """Psychrometric chart renderer with app-level post-draw layers.
+
+    The core renderer owns the established rendering pipeline. Explicit
+    intervention zones are drawn immediately after that pipeline completes so
+    they can use the finalized T-W axis domain.
+    """
+
+    def draw(self) -> Axes:
+        ax = super().draw()
+        draw_intervention_zones(
+            ax,
+            getattr(self, "intervention_zones", None),
+            pressure=self.cfg.pressure,
+        )
+        return ax
+
 
 __all__ = ["PsychChart"]

--- a/src/psychchart/plot/__init__.py
+++ b/src/psychchart/plot/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from matplotlib.axes import Axes
 
 from .core import PsychChart as _BasePsychChart
@@ -12,9 +14,14 @@ class PsychChart(_BasePsychChart):
     """Psychrometric chart renderer with app-level post-draw layers.
 
     The core renderer owns the established rendering pipeline. Explicit
-    intervention zones are drawn immediately after that pipeline completes so
-    they can use the finalized T-W axis domain.
+    intervention zones are accepted by the public wrapper and drawn immediately
+    after the core pipeline completes so they can use the finalized T-W axis
+    domain.
     """
+
+    def __init__(self, *args: Any, intervention_zones=None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.intervention_zones = intervention_zones
 
     def draw(self) -> Axes:
         ax = super().draw()

--- a/src/psychchart/plot/intervention_zones.py
+++ b/src/psychchart/plot/intervention_zones.py
@@ -198,15 +198,20 @@ def draw_rule_region(
         config.inappropriate_zorder if is_bad else config.zorder
     )
 
+    contour_kwargs = {
+        "levels": [0.5, 1.5],
+        "colors": [rule.facecolor],
+        "alpha": rule.alpha * config.alpha_scale,
+        "zorder": zorder,
+    }
+    if rule.hatch:
+        contour_kwargs["hatches"] = [rule.hatch]
+
     contour = ax.contourf(
         T_grid,
         W_grid,
         field,
-        levels=[0.5, 1.5],
-        colors=[rule.facecolor],
-        alpha=rule.alpha * config.alpha_scale,
-        hatches=[rule.hatch] if rule.hatch else None,
-        zorder=zorder,
+        **contour_kwargs,
     )
     artists.append(contour)
 

--- a/tests/test_intervention_zones_pipeline.py
+++ b/tests/test_intervention_zones_pipeline.py
@@ -1,0 +1,51 @@
+import matplotlib.pyplot as plt
+
+from psychchart import PsychChart, load_chart_config
+from psychchart.config import AppConfig, InterventionZonesConfig
+
+
+def test_app_config_accepts_intervention_zones():
+    cfg = AppConfig.model_validate(
+        {
+            "chart": {
+                "t_min": 10,
+                "t_max": 45,
+                "y_min": 0.0,
+                "y_max": 0.035,
+                "pressure": 101325,
+                "xlabel": "Dry-bulb temperature (°C)",
+                "ylabel": "Humidity ratio (kg/kg)",
+                "output": "intervention_zones_test.png",
+                "dpi": 150,
+            },
+            "intervention_zones": {
+                "enabled": True,
+                "rules": [
+                    {
+                        "name": "ventilation",
+                        "label": "Ventilation",
+                        "when": {"t_gte": 28, "w_lt": 0.020},
+                        "vector": [-3.0, 0.0],
+                    }
+                ],
+            },
+        }
+    )
+
+    assert isinstance(cfg.intervention_zones, InterventionZonesConfig)
+    payload = cfg.to_runtime_payload()
+    assert payload["intervention_zones"] is cfg.intervention_zones
+
+
+def test_intervention_zones_yaml_render_smoke():
+    data = load_chart_config("examples/intervention_zones_minimal.yaml")
+    chart = PsychChart(**data)
+
+    try:
+        chart.draw()
+        text_values = {text.get_text() for text in chart.ax.texts}
+        assert "Ventilation" in text_values
+        assert "Reduce humidity" in text_values
+        assert "Avoid evaporative\nhot and humid" in text_values
+    finally:
+        plt.close(chart.fig)


### PR DESCRIPTION
## Summary

This PR integrates the standalone intervention-zone layer into the YAML-driven rendering workflow.

It adds:

- `intervention_zones` to `AppConfig`;
- `intervention_zones` to the runtime payload returned by the loader;
- public exports for intervention-zone configuration models;
- a public `PsychChart` wrapper that accepts `intervention_zones` and draws the layer after the core chart draw, when T-W axis limits are already finalized;
- `examples/intervention_zones_minimal.yaml`;
- a pipeline smoke test covering YAML loading and rendering.

## Why the layer is drawn after the core draw

The intervention-zone renderer needs the final chart domain from the Matplotlib axes. Drawing it before axis finalization can produce masks in the wrong T-W domain. This PR draws the layer after `super().draw()` so labels, masks and vectors use the finalized domain.

## Validation

Please validate locally before merge:

```bash
git checkout main
git pull origin main
git checkout intervention-zones-pipeline
git pull origin intervention-zones-pipeline

pytest tests/test_intervention_zones.py
pytest tests/test_intervention_zones_pipeline.py
pytest
psychchart examples/intervention_zones_minimal.yaml
```

## Scope

This PR does not modify `src/psychchart/plot/core.py`. The integration is kept in `src/psychchart/plot/__init__.py` through a wrapper around the established core renderer.