### PR TITLE
Prepare release version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [1.1.0] - 2026-05-04
+
+### Added
+- FastAPI `/readout` endpoint for point-based psychrometric diagnostics, returning temperature, RH, humidity ratio, enthalpy, dew point and ITU values.
+- Interactive frontend workspace base layout derived from the validated `marsh-ui` work.
+- Frontend API helpers for rendering, binary export and readout calls.
+- Frontend package lockfile for reproducible `npm ci` builds.
+- Labeled `index_zones` with configurable internal labels, manual/automatic placement and style options.
+- Standalone `intervention_zones` configuration and rendering layer for explicit physical intervention regions in T-W space.
+- YAML/rendering pipeline integration for `intervention_zones`.
+- Minimal intervention-zone example: `examples/intervention_zones_minimal.yaml`.
+- Minimal labeled ITU index-zone example: `examples/index_zone_itu_labeled.yaml`.
+- Branching and release workflow documentation.
+- Release-closing roadmap for version `1.1.0`.
+
+### Changed
+- Public plotting interface now accepts app-level `intervention_zones` and draws them after the core chart domain is finalized.
+- `intervention_zones` support recommended and inappropriate actions, labels, boundaries, hatches, vectors and saturation clipping.
+- Branch management policy now favors short-lived feature/fix/docs branches, an integration branch and release-only updates to `main`.
+
+### Fixed
+- Package version metadata is aligned for the `1.1.0` release.
+- Public `psychchart.__version__` is aligned with package metadata.
+- Intervention-zone contour fills no longer pass null hatch lists to Matplotlib, avoiding savefig failures in backends that expect iterable hatches.
+- Obsolete long-lived development branches were cleaned from the remote repository after their useful changes were extracted.
+
 ## [1.0.1] - 2026-05-01
 
 ### Added
@@ -84,7 +110,7 @@
 ## [0.2.0] - 2026-01-11
 ### Added
 - Modular plotting backend (`plot/` package)
-- Support for index fields (e.g. ITU, ITI) over psychrometric domain
+- Support for index fields (e.g., ITU, ITI) over psychrometric domain
 - Smoke tests for index field computation and rendering
 - New illustrative examples (cartesian ITU, cattle breeds)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "psychchart"
-version = "1.0.1"
+version = "1.1.0"
 description = "Psychrometric chart generator with YAML-driven configuration"
 readme = "README.md"
 license = { text = "LGPL-3.0" }

--- a/src/psychchart/__init__.py
+++ b/src/psychchart/__init__.py
@@ -67,7 +67,7 @@ or
 # NOTE:
 # The version string is intentionally defined here to make it accessible
 # programmatically (e.g., psychchart.__version__) and by packaging tools.
-__version__ = '1.0.0'
+__version__ = "1.1.0"
 
 
 # =============================================================================
@@ -76,7 +76,7 @@ __version__ = '1.0.0'
 
 # Configuration-related classes
 # These define the declarative structure of the chart (axes, isopleths, zones).
-from .config import ChartConfig, IsoSet, Zone, Point,  IndexConfig, IndexZone, ObservationsConfig
+from .config import ChartConfig, IsoSet, Zone, Point, IndexConfig, IndexZone, ObservationsConfig
 
 # Main plotting interface
 # This is the high-level object responsible for rendering the psychrometric chart.
@@ -139,6 +139,6 @@ __all__ = [
 #
 # >>> import psychchart
 # >>> psychchart.__version__
-# '0.1.0'
+# '1.1.0'
 #
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+import importlib.metadata as metadata
+
+import psychchart
+
+
+def test_public_version_matches_package_metadata():
+    """The public package version must match installed package metadata."""
+    assert psychchart.__version__ == metadata.version("psychchart")


### PR DESCRIPTION
## Summary

This PR prepares the package metadata for the `1.1.0` release.

It updates:

- `pyproject.toml` package version to `1.1.0`;
- `psychchart.__version__` to `1.1.0`;
- `CHANGELOG.md` with a new `[1.1.0]` section;
- adds a test to ensure the public version matches installed package metadata.

## Why

The project already had newer functionality after `1.0.1`, including readout API support, frontend base work, labeled index zones, intervention zones and release/branching documentation. This PR aligns package metadata with the planned minor release.

## Validation

Please validate locally before merge:

```bash
git checkout main
git pull origin main
git checkout release/prepare-1.1.0
git pull origin release/prepare-1.1.0

python -m pip install -e ".[dev]"
python -c "import psychchart; print(psychchart.__version__)"
python -c "import importlib.metadata as m; print(m.version('psychchart'))"
pytest tests/test_version.py
pytest
```

Expected version output:

```text
1.1.0
```

## Scope

Release metadata and changelog only. No runtime behavior changes.