### PR TITLE
Support formatted annotation labels in data layers

### DIFF
--- a/docs/ANNOTATION_TEMPLATES.md
+++ b/docs/ANNOTATION_TEMPLATES.md
@@ -1,0 +1,56 @@
+# Annotation label templates
+
+`annotate` render blocks can format labels from the full processed data-layer row.
+
+This is useful for temporal overlays, where the label often needs more than the default `time` and `value` placeholders. For example, a CTA trajectory may need to show only the hour, the accumulated load, or a compact two-line label.
+
+## Available placeholders
+
+For each annotated point, the template context includes:
+
+- `time`: value from `time_field`, when configured;
+- `value`: value from `value_field`, when configured;
+- every column available in the processed data layer, using the column name directly.
+
+Because all dataframe columns are exposed, templates may use fields such as `data_hora`, `hora`, `cta`, `cta_classe`, `temperatura`, or any other column present in the input file.
+
+Datetime-like strings are parsed before formatting, so Python datetime format codes can be used.
+
+## Examples
+
+Show only the hour from a datetime column:
+
+```yaml
+render:
+  - type: annotate
+    every: 3
+    time_field: data_hora
+    value_field: cta
+    template: "{data_hora:%Hh}"
+```
+
+Show hour and rounded CTA:
+
+```yaml
+render:
+  - type: annotate
+    every: 3
+    time_field: data_hora
+    value_field: cta
+    template: "{data_hora:%Hh}\nCTA:{cta:.0f}"
+```
+
+Keep the legacy placeholders:
+
+```yaml
+render:
+  - type: annotate
+    every: 3
+    time_field: data_hora
+    value_field: cta
+    template: "{time:%Y-%m-%d %Hh}\n(CTA:{value:.0f})"
+```
+
+## Notes
+
+The template uses Python's standard `str.format` syntax. This means numeric formatting such as `{cta:.0f}` and datetime formatting such as `{data_hora:%H:%M}` are supported when the values are compatible.

--- a/docs/psychchart_user_docs_markdown/docs/config/legacy_temporal_overlays.md
+++ b/docs/psychchart_user_docs_markdown/docs/config/legacy_temporal_overlays.md
@@ -53,10 +53,10 @@ temporal_overlays:
     data: data/trajectory.csv
     t_col: temperature
     rh_col: relative_humidity
-    time_col: hour
+    time_col: data_hora
     cta_col: cta
     annotate_every: 3
-    annotation_template: "{time}h\n(CTA:{value:.0f})"
+    annotation_template: "{data_hora:%Hh}\nCTA:{cta:.0f}"
     show_path: true
     path_color: blue
     path_alpha: 0.6
@@ -64,6 +64,34 @@ temporal_overlays:
     point_size: 42.0
     point_edgecolor: black
     point_edgewidth: 0.8
+```
+
+## Formatação dos rótulos
+
+O campo `annotation_template` usa a sintaxe padrão de `str.format` do Python.
+
+Na renderização canônica, o contexto do template contém:
+
+- `time`: valor da coluna definida por `time_col`;
+- `value`: valor do campo acumulado convertido para `CTA`;
+- todas as colunas do dataframe processado, acessíveis pelo próprio nome.
+
+Isso permite rótulos compactos, por exemplo:
+
+```yaml
+annotation_template: "{data_hora:%Hh}"
+```
+
+ou rótulos com CTA arredondada:
+
+```yaml
+annotation_template: "{data_hora:%Hh}\nCTA:{cta:.0f}"
+```
+
+Também continua válido usar os nomes legados:
+
+```yaml
+annotation_template: "{time:%Y-%m-%d %Hh}\n(CTA:{value:.0f})"
 ```
 
 ## Observações importantes
@@ -79,11 +107,12 @@ temporal_overlays:
   - sempre é criado um `scatter` com `value: CTA`
   - quando `annotate_every` não é `None`, é criado um `annotate`
 - O `format` é fixado como `csv` na conversão automática.
+- O renderizador de anotações expõe `time`, `value` e todas as colunas do dataframe processado ao `annotation_template`.
 
 ### Confirmado no código, mas com ressalva
 
-- O renderizador canônico de anotações trabalha com placeholders `time` e `value`.
-- A conversão automática para `data_layers` usa `value_field: CTA`.
+- `value` aponta para o campo canônico `CTA` criado durante a conversão.
+- A coluna original indicada em `cta_col` também pode ser usada no template quando permanecer presente no dataframe carregado.
 
 ### Não foi possível validar
 
@@ -92,5 +121,7 @@ temporal_overlays:
 
 ## Erros comuns
 
-- Usar `annotation_template` com `{cta}` em vez de `{value}` quando a trajetória for convertida para o formato canônico de anotações.
+- Usar um nome de campo que não existe no CSV ou no dataframe processado.
+- Usar formato numérico, como `{cta:.0f}`, em uma coluna textual.
+- Usar formato de data, como `{data_hora:%Hh}`, em uma coluna que não pode ser convertida para data/hora.
 - Esperar que `format` seja detectado automaticamente: na conversão enviada, ele é fixado em `csv`.

--- a/src/psychchart/plot/data_renderers/annotate.py
+++ b/src/psychchart/plot/data_renderers/annotate.py
@@ -4,9 +4,62 @@ Renderer for periodic annotations over processed data layers.
 
 from __future__ import annotations
 
+from datetime import date, datetime
+from typing import Any
+
+import pandas as pd
 from matplotlib.axes import Axes
 
 from psychchart.data.layer_runtime import ProcessedDataLayer
+
+
+def _coerce_datetime(value: Any) -> Any:
+    """Return a datetime-like value when a scalar can be safely parsed."""
+    if isinstance(value, (datetime, date, pd.Timestamp)):
+        return value
+
+    if isinstance(value, str):
+        try:
+            parsed = pd.to_datetime(value, errors="raise")
+        except (TypeError, ValueError):
+            return value
+
+        if pd.isna(parsed):
+            return value
+        return parsed
+
+    return value
+
+
+def _build_annotation_context(row, cfg) -> dict[str, Any]:
+    """Build the formatting context used by annotation templates.
+
+    The public template keys remain backward compatible:
+
+    - ``time`` comes from ``cfg.time_field``
+    - ``value`` comes from ``cfg.value_field``
+
+    In addition, all dataframe columns are exposed by their column names. This
+    allows labels such as ``{hora:02.0f}``, ``{cta:.0f}``, or
+    ``{data_hora:%H:%M}`` when those columns exist in the processed layer.
+    """
+    context: dict[str, Any] = {}
+
+    for key, value in row.items():
+        context[str(key)] = _coerce_datetime(value)
+
+    context["time"] = (
+        context.get(cfg.time_field, "")
+        if cfg.time_field
+        else ""
+    )
+    context["value"] = (
+        context.get(cfg.value_field, "")
+        if cfg.value_field
+        else ""
+    )
+
+    return context
 
 
 def draw_annotate(
@@ -39,11 +92,7 @@ def draw_annotate(
         if i % cfg.every != 0:
             continue
 
-        context = {
-            "time": row[cfg.time_field] if cfg.time_field else "",
-            "value": row[cfg.value_field] if cfg.value_field else "",
-        }
-
+        context = _build_annotation_context(row, cfg)
         label = cfg.template.format(**context)
 
         ax.text(

--- a/tests/plot/test_annotate_renderer.py
+++ b/tests/plot/test_annotate_renderer.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from psychchart.plot.data_renderers.annotate import _build_annotation_context
+
+
+def test_annotation_context_exposes_named_dataframe_columns():
+    row = pd.Series(
+        {
+            "data_hora": "2025-11-08 15:00:00",
+            "hora": 15,
+            "cta": 181.7,
+            "cta_classe": "acumulo elevado",
+        }
+    )
+    cfg = SimpleNamespace(time_field="data_hora", value_field="cta")
+
+    context = _build_annotation_context(row, cfg)
+
+    assert context["hora"] == 15
+    assert context["cta"] == 181.7
+    assert context["cta_classe"] == "acumulo elevado"
+    assert context["time"] == context["data_hora"]
+    assert context["value"] == 181.7
+
+
+def test_annotation_template_supports_datetime_and_numeric_formatting():
+    row = pd.Series(
+        {
+            "data_hora": "2025-11-08 15:00:00",
+            "hora": 15,
+            "cta": 181.7,
+        }
+    )
+    cfg = SimpleNamespace(time_field="data_hora", value_field="cta")
+
+    context = _build_annotation_context(row, cfg)
+    label = "{data_hora:%H:%M}\nCTA:{cta:.0f}\nH:{hora:02d}".format(**context)
+
+    assert label == "15:00\nCTA:182\nH:15"
+
+
+def test_annotation_template_keeps_legacy_time_and_value_placeholders():
+    row = pd.Series(
+        {
+            "data_hora": "2025-11-08 10:00:00",
+            "cta": 95.4,
+        }
+    )
+    cfg = SimpleNamespace(time_field="data_hora", value_field="cta")
+
+    context = _build_annotation_context(row, cfg)
+    label = "{time:%Y-%m-%d %Hh}\n(CTA:{value:.0f})".format(**context)
+
+    assert label == "2025-11-08 10h\n(CTA:95)"


### PR DESCRIPTION
## Summary

This PR improves annotation labels for temporal/data-layer overlays.

### What changed

- Allows annotation templates to access the full processed dataframe row, not only the legacy `time` and `value` placeholders.
- Keeps backward compatibility with `{time}` and `{value}`.
- Coerces datetime-like string values before formatting, enabling templates such as `{data_hora:%Hh}` and `{data_hora:%H:%M}`.
- Adds tests covering named dataframe columns, datetime formatting, numeric formatting, and legacy placeholders.
- Documents annotation templates and updates the legacy `temporal_overlays` documentation.

## Example

```yaml
temporal_overlays:
  - type: CTA_TRAJECTORY
    data: resultados_dissertacao/carta_dinamica_cta_resumo.csv
    t_col: temperatura
    rh_col: umidade
    time_col: data_hora
    cta_col: cta
    annotate_every: 3
    annotation_template: "{data_hora:%Hh}\nCTA:{cta:.0f}"
```

This should allow compact labels for the dynamic CTA psychrometric chart, avoiding overcrowded full datetime labels.

## Notes

The implementation is intentionally limited to rendering/formatting behavior. It does not change psychrometric calculations, data loading, CTA computation, or semantic classification.